### PR TITLE
feat(ux): drag, mode attaque et summoning sickness

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,4 +1,4 @@
-import { DndContext, type DragEndEvent, useDroppable } from '@dnd-kit/core';
+import { DndContext, type DragEndEvent, useDroppable, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { useGameStore } from '../../store/gameStore.js';
 import { BattlefieldUnit } from '../Card/CardComponent.js';
 import { Hand } from '../Hand/Hand.js';
@@ -118,11 +118,17 @@ function Battlefield({ playerId }: { playerId: PlayerId }) {
 
 // ─── Main Board ───────────────────────────────────────────────────────────────
 export function Board() {
-  const { gameState, dispatch, setSelection } = useGameStore(s => ({
+  const { gameState, selection, dispatch, setSelection } = useGameStore(s => ({
     gameState: s.gameState,
+    selection: s.selection,
     dispatch: s.dispatch,
     setSelection: s.setSelection,
   }));
+
+  // Require 8px of movement before drag activates — allows normal clicks to work
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
 
   const activeId = gameState.activePlayerId;
   const opponentId: PlayerId = activeId === 'p1' ? 'p2' : 'p1';
@@ -153,7 +159,7 @@ export function Board() {
   const cycleBg: Record<string, string> = { dawn: 'text-orange-300', day: 'text-yellow-200', night: 'text-blue-300' };
 
   return (
-    <DndContext onDragEnd={handleDragEnd}>
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
       <div
         className="flex h-screen w-screen bg-gray-950 overflow-hidden select-none"
         onClick={handleBoardClick}
@@ -194,6 +200,13 @@ export function Board() {
           <div className="flex justify-center px-4 pb-1">
             <Battlefield playerId={opponentId} />
           </div>
+
+          {/* Attack mode banner */}
+          {selection.kind === 'attacking' && (
+            <div className="mx-4 py-1 text-center text-sm font-bold text-red-300 bg-red-900/40 border border-red-700 rounded animate-pulse">
+              ⚔ Mode Attaque — clique une unité ou le héros adverse
+            </div>
+          )}
 
           {/* Divider */}
           <div className="flex items-center gap-2 px-4 my-1">

--- a/src/components/Card/CardComponent.tsx
+++ b/src/components/Card/CardComponent.tsx
@@ -25,7 +25,11 @@ export function HandCard({ card, playable, onClick, isDragging }: HandCardProps)
       className={[
         'relative flex flex-col rounded-lg border-2 select-none',
         'transition-all duration-150',
-        playable ? 'border-yellow-400 shadow-lg shadow-yellow-400/30 cursor-grab active:cursor-grabbing hover:-translate-y-1' : 'border-gray-600 opacity-50 cursor-default',
+        playable
+          ? isUnit
+            ? 'border-yellow-400 shadow-lg shadow-yellow-400/30 cursor-grab active:cursor-grabbing hover:-translate-y-1'
+            : 'border-yellow-400 shadow-lg shadow-yellow-400/30 cursor-pointer hover:-translate-y-1'
+          : 'border-gray-600 opacity-50 cursor-default',
         card.faction === 'orisha' ? 'bg-amber-950' : card.faction === 'zulu' ? 'bg-green-950' : 'bg-gray-900',
       ].join(' ')}
       style={{ width: 80, minHeight: 110, opacity }}

--- a/src/components/Card/CardComponent.tsx
+++ b/src/components/Card/CardComponent.tsx
@@ -23,9 +23,9 @@ export function HandCard({ card, playable, onClick, isDragging }: HandCardProps)
       onClick={playable ? onClick : undefined}
       title={card.effects.map(e => e.description).join('\n') || card.name}
       className={[
-        'relative flex flex-col rounded-lg border-2 cursor-pointer select-none',
-        'transition-transform duration-150 hover:scale-105 hover:-translate-y-1',
-        playable ? 'border-yellow-400 shadow-lg shadow-yellow-400/30' : 'border-gray-600 opacity-50 cursor-not-allowed',
+        'relative flex flex-col rounded-lg border-2 select-none',
+        'transition-all duration-150',
+        playable ? 'border-yellow-400 shadow-lg shadow-yellow-400/30 cursor-grab active:cursor-grabbing hover:-translate-y-1' : 'border-gray-600 opacity-50 cursor-default',
         card.faction === 'orisha' ? 'bg-amber-950' : card.faction === 'zulu' ? 'bg-green-950' : 'bg-gray-900',
       ].join(' ')}
       style={{ width: 80, minHeight: 110, opacity }}
@@ -107,6 +107,12 @@ export function BattlefieldUnit({ unit, isSelected, isTargetable, isOwn, onClick
       {/* Taunt indicator */}
       {unit.card.keywords.includes('taunt') && (
         <span className="absolute top-0 right-0 bg-orange-700 text-white rounded-bl px-0.5" style={{ fontSize: 8 }}>PROV</span>
+      )}
+      {/* Summoning sickness */}
+      {unit.justSummoned && (
+        <span className="absolute inset-0 flex items-center justify-center rounded-lg bg-black/50 text-white text-center leading-tight" style={{ fontSize: 7 }}>
+          Invoqué<br/>ce tour
+        </span>
       )}
 
       <div className="pt-1">

--- a/src/components/Hand/Hand.tsx
+++ b/src/components/Hand/Hand.tsx
@@ -8,30 +8,45 @@ interface DraggableCardProps {
   card: Card;
   index: number;
   playable: boolean;
-  isOpponent: boolean;
+  onClickNonUnit?: () => void;
 }
 
-function DraggableCard({ card, index, playable, isOpponent }: DraggableCardProps) {
+function DraggableCard({ card, index, playable, onClickNonUnit }: DraggableCardProps) {
+  const isUnit = card.type === 'unit';
+
+  // Only units are draggable — spells/rituals use click
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: `hand-card-${index}`,
     data: { cardId: card.id, cardIndex: index, cardType: card.type },
-    disabled: !playable || isOpponent,
+    disabled: !playable || !isUnit,
   });
 
   const style = transform ? { transform: CSS.Translate.toString(transform), zIndex: 50 } : undefined;
 
-  // Opponent: show face-down cards
-  if (isOpponent) {
-    return (
-      <div className="w-14 h-20 bg-gray-800 border-2 border-gray-600 rounded-lg flex items-center justify-center">
-        <span className="text-gray-600 text-2xl">🂠</span>
-      </div>
-    );
-  }
-
   return (
-    <div ref={setNodeRef} style={style} {...listeners} {...attributes}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      // Listeners only on units (for drag); spells/rituals get onClick
+      {...(isUnit ? listeners : {})}
+      {...(isUnit ? attributes : {})}
+      onClick={!isUnit && playable ? onClickNonUnit : undefined}
+    >
       <HandCard card={card} playable={playable} isDragging={isDragging} />
+    </div>
+  );
+}
+
+interface FaceDownCardProps { count: number }
+function FaceDownCards({ count }: FaceDownCardProps) {
+  return (
+    <div className="flex items-center justify-center gap-2 min-h-[88px]">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="w-14 h-20 bg-gray-800 border-2 border-gray-600 rounded-lg flex items-center justify-center">
+          <span className="text-gray-600 text-2xl">🂠</span>
+        </div>
+      ))}
+      {count === 0 && <span className="text-gray-600 text-sm">Main vide</span>}
     </div>
   );
 }
@@ -53,64 +68,46 @@ export function Hand({ playerId, isOpponent = false }: HandProps) {
   const isActive = gameState.activePlayerId === playerId;
 
   if (isOpponent) {
-    return (
-      <div className="flex items-center justify-center gap-2 min-h-[88px]">
-        {player.hand.map((_, i) => (
-          <DraggableCard key={i} card={_} index={i} playable={false} isOpponent />
-        ))}
-        {player.hand.length === 0 && <span className="text-gray-600 text-sm">Main vide</span>}
-      </div>
-    );
+    return <FaceDownCards count={player.hand.length} />;
   }
 
-  function handleCardClick(card: Card) {
-    if (!isActive) return;
-    if (card.type === 'unit') {
-      // Handled via drag-and-drop; click just selects for quick play
-      return;
-    }
+  function handleNonUnitClick(card: Card) {
+    if (!isActive || player.energy < card.cost) return;
+
     if (card.type === 'ritual') {
-      if (player.energy >= card.cost) {
-        dispatch({ type: 'PLAY_RITUAL', playerId, cardId: card.id });
-      }
+      dispatch({ type: 'PLAY_RITUAL', playerId, cardId: card.id });
       return;
     }
+
     if (card.type === 'spell') {
       const needsTarget = card.effects.some(e =>
         e.resolve.kind === 'damage' &&
         (e.resolve.target.scope === 'choose_enemy' || e.resolve.target.scope === 'choose_ally')
       );
-      if (player.energy >= card.cost) {
-        if (needsTarget) {
-          setSelection({ kind: 'spell', cardId: card.id, needsTarget: true });
-        } else {
-          dispatch({ type: 'PLAY_SPELL', playerId, cardId: card.id });
-        }
+      if (needsTarget) {
+        setSelection({ kind: 'spell', cardId: card.id, needsTarget: true });
+      } else {
+        dispatch({ type: 'PLAY_SPELL', playerId, cardId: card.id });
       }
     }
   }
 
   return (
-    <div className="flex items-end justify-center gap-2 min-h-[110px] py-1">
+    <div className="flex items-end justify-center gap-2 min-h-[110px] py-1 flex-wrap">
       {player.hand.map((card, i) => {
         const playable = isActive && player.energy >= card.cost;
         const isSpellSelected = selection.kind === 'spell' && selection.cardId === card.id;
         return (
-          <div key={i} className={isSpellSelected ? 'ring-2 ring-yellow-400 rounded-lg' : ''}>
+          <div
+            key={i}
+            className={isSpellSelected ? 'ring-2 ring-yellow-400 rounded-lg' : ''}
+          >
             <DraggableCard
               card={card}
               index={i}
               playable={playable}
-              isOpponent={false}
+              onClickNonUnit={() => handleNonUnitClick(card)}
             />
-            {/* Click handler for non-unit cards */}
-            {card.type !== 'unit' && playable && (
-              <div
-                className="absolute inset-0 cursor-pointer"
-                onClick={() => handleCardClick(card)}
-                style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
-              />
-            )}
           </div>
         );
       })}


### PR DESCRIPTION
## Résumé

- **Drag précis** : `PointerSensor` avec seuil de 8px — distingue clic et drag, élimine les déclenchements accidentels
- **Mode attaque** : bannière animée en rouge pulsant quand une unité est sélectionnée pour attaquer
- **Summoning sickness** : overlay semi-transparent "Invoqué ce tour" sur les unités qui ne peuvent pas attaquer
- **Refactor Hand** : unités = drag uniquement, sorts/rituels = clic uniquement — supprime l'overlay absolu hacky
- **`FaceDownCards`** : composant dédié pour la main adverse, code plus lisible

## Fichiers modifiés

- `src/components/Board/Board.tsx` — sensors + bannière attaque
- `src/components/Card/CardComponent.tsx` — curseurs + summoning sickness
- `src/components/Hand/Hand.tsx` — refactor drag/clic + FaceDownCards

## Plan de test

- [ ] Jouer une carte unité en la glissant sur le plateau
- [ ] Cliquer sur une carte sort/rituel pour la jouer
- [ ] Sélectionner une unité pour attaquer → vérifier la bannière rouge
- [ ] Poser une unité → vérifier l'overlay "Invoqué ce tour" le tour suivant il disparaît
- [ ] Vérifier la main adverse (cartes face cachée)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)