### PR TITLE
feat(ux): feedback global cartes non jouables

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { DndContext, type DragEndEvent, useDroppable, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { useGameStore } from '../../store/gameStore.js';
 import { BattlefieldUnit } from '../Card/CardComponent.js';
@@ -118,11 +119,13 @@ function Battlefield({ playerId }: { playerId: PlayerId }) {
 
 // ─── Main Board ───────────────────────────────────────────────────────────────
 export function Board() {
-  const { gameState, selection, dispatch, setSelection } = useGameStore(s => ({
+  const { gameState, selection, uiToast, dispatch, setSelection, clearUiToast } = useGameStore(s => ({
     gameState: s.gameState,
     selection: s.selection,
+    uiToast: s.uiToast,
     dispatch: s.dispatch,
     setSelection: s.setSelection,
+    clearUiToast: s.clearUiToast,
   }));
 
   // Require 8px of movement before drag activates — allows normal clicks to work
@@ -157,6 +160,12 @@ export function Board() {
 
   const activeLabel = `${activeId.toUpperCase()} — ${activePlayer.hero.name.split(',')[0]}`;
   const cycleBg: Record<string, string> = { dawn: 'text-orange-300', day: 'text-yellow-200', night: 'text-blue-300' };
+
+  useEffect(() => {
+    if (!uiToast) return;
+    const timeout = window.setTimeout(() => clearUiToast(), 2200);
+    return () => window.clearTimeout(timeout);
+  }, [uiToast, clearUiToast]);
 
   return (
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
@@ -245,6 +254,12 @@ export function Board() {
         <div className="w-52 border-l border-gray-800 p-3 flex flex-col">
           <GameLog />
         </div>
+
+        {uiToast && (
+          <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-lg border border-red-700 bg-red-950/90 text-red-200 text-sm font-semibold shadow-lg shadow-red-900/40 animate-pulse">
+            {uiToast}
+          </div>
+        )}
       </div>
     </DndContext>
   );

--- a/src/components/GameLog/GameLog.tsx
+++ b/src/components/GameLog/GameLog.tsx
@@ -8,14 +8,15 @@ const CYCLE_COLOR: Record<string, string> = {
 };
 
 export function GameLog() {
-  const { gameState } = useGameStore(s => ({ gameState: s.gameState }));
+  const { gameState, uiLog } = useGameStore(s => ({ gameState: s.gameState, uiLog: s.uiLog }));
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [gameState.log.length]);
+  }, [gameState.log.length, uiLog.length]);
 
   const recent = gameState.log.slice(-40);
+  const recentUi = uiLog.slice(-12);
 
   return (
     <div className="flex flex-col h-full">
@@ -40,6 +41,16 @@ export function GameLog() {
             </div>
           );
         })}
+        {recentUi.length > 0 && (
+          <div className="mt-2 pt-1 border-t border-gray-800">
+            {recentUi.map((msg, i) => (
+              <div key={`${msg}-${i}`} className="text-xs leading-snug text-red-300">
+                <span className="font-bold">[ui] </span>
+                {msg}
+              </div>
+            ))}
+          </div>
+        )}
         <div ref={bottomRef} />
       </div>
 

--- a/src/components/Hand/Hand.tsx
+++ b/src/components/Hand/Hand.tsx
@@ -9,9 +9,10 @@ interface DraggableCardProps {
   index: number;
   playable: boolean;
   onClickNonUnit?: () => void;
+  onAttemptWhenLocked?: () => void;
 }
 
-function DraggableCard({ card, index, playable, onClickNonUnit }: DraggableCardProps) {
+function DraggableCard({ card, index, playable, onClickNonUnit, onAttemptWhenLocked }: DraggableCardProps) {
   const isUnit = card.type === 'unit';
 
   // Only units are draggable — spells/rituals use click
@@ -30,7 +31,16 @@ function DraggableCard({ card, index, playable, onClickNonUnit }: DraggableCardP
       // Listeners only on units (for drag); spells/rituals get onClick
       {...(isUnit ? listeners : {})}
       {...(isUnit ? attributes : {})}
-      onClick={!isUnit && playable ? onClickNonUnit : undefined}
+      onPointerDown={() => {
+        if (!playable) onAttemptWhenLocked?.();
+      }}
+      onClick={() => {
+        if (!isUnit && playable) {
+          onClickNonUnit?.();
+          return;
+        }
+        if (!playable) onAttemptWhenLocked?.();
+      }}
     >
       <HandCard card={card} playable={playable} isDragging={isDragging} />
     </div>
@@ -57,11 +67,12 @@ interface HandProps {
 }
 
 export function Hand({ playerId, isOpponent = false }: HandProps) {
-  const { gameState, selection, setSelection, dispatch } = useGameStore(s => ({
+  const { gameState, selection, setSelection, dispatch, pushUiFeedback } = useGameStore(s => ({
     gameState: s.gameState,
     selection: s.selection,
     setSelection: s.setSelection,
     dispatch: s.dispatch,
+    pushUiFeedback: s.pushUiFeedback,
   }));
 
   const player = gameState.players[playerId];
@@ -92,28 +103,46 @@ export function Hand({ playerId, isOpponent = false }: HandProps) {
     }
   }
 
+  function handleLockedCardAttempt(card: Card) {
+    if (!isActive) {
+      pushUiFeedback('Ce n’est pas ton tour.');
+      return;
+    }
+    if (player.energy < card.cost) {
+      pushUiFeedback(`Énergie insuffisante: ${player.energy}/${card.cost}.`);
+      return;
+    }
+    pushUiFeedback('Action indisponible pour cette carte.');
+  }
+
   return (
-    <div className="flex items-end justify-center gap-2 min-h-[110px] py-1 flex-wrap">
-      {player.hand.map((card, i) => {
-        const playable = isActive && player.energy >= card.cost;
-        const isSpellSelected = selection.kind === 'spell' && selection.cardId === card.id;
-        return (
-          <div
-            key={i}
-            className={isSpellSelected ? 'ring-2 ring-yellow-400 rounded-lg' : ''}
-          >
-            <DraggableCard
-              card={card}
-              index={i}
-              playable={playable}
-              onClickNonUnit={() => handleNonUnitClick(card)}
-            />
-          </div>
-        );
-      })}
-      {player.hand.length === 0 && (
-        <span className="text-gray-600 text-sm">Main vide</span>
-      )}
+    <div className="flex flex-col items-center gap-1">
+      <div className="text-gray-500 text-xs select-none">
+        Unités: glisser | Sorts/Rituels: cliquer
+      </div>
+      <div className="flex items-end justify-center gap-2 min-h-[110px] py-1 flex-wrap">
+        {player.hand.map((card, i) => {
+          const playable = isActive && player.energy >= card.cost;
+          const isSpellSelected = selection.kind === 'spell' && selection.cardId === card.id;
+          return (
+            <div
+              key={i}
+              className={isSpellSelected ? 'ring-2 ring-yellow-400 rounded-lg' : ''}
+            >
+              <DraggableCard
+                card={card}
+                index={i}
+                playable={playable}
+                onClickNonUnit={() => handleNonUnitClick(card)}
+                onAttemptWhenLocked={() => handleLockedCardAttempt(card)}
+              />
+            </div>
+          );
+        })}
+        {player.hand.length === 0 && (
+          <span className="text-gray-600 text-sm">Main vide</span>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Hand/Hand.tsx
+++ b/src/components/Hand/Hand.tsx
@@ -31,9 +31,6 @@ function DraggableCard({ card, index, playable, onClickNonUnit, onAttemptWhenLoc
       // Listeners only on units (for drag); spells/rituals get onClick
       {...(isUnit ? listeners : {})}
       {...(isUnit ? attributes : {})}
-      onPointerDown={() => {
-        if (!playable) onAttemptWhenLocked?.();
-      }}
       onClick={() => {
         if (!isUnit && playable) {
           onClickNonUnit?.();
@@ -77,6 +74,7 @@ export function Hand({ playerId, isOpponent = false }: HandProps) {
 
   const player = gameState.players[playerId];
   const isActive = gameState.activePlayerId === playerId;
+  const showInteractionHint = gameState.turn <= 3;
 
   if (isOpponent) {
     return <FaceDownCards count={player.hand.length} />;
@@ -117,9 +115,11 @@ export function Hand({ playerId, isOpponent = false }: HandProps) {
 
   return (
     <div className="flex flex-col items-center gap-1">
-      <div className="text-gray-500 text-xs select-none">
-        Unités: glisser | Sorts/Rituels: cliquer
-      </div>
+      {showInteractionHint && (
+        <div className="text-gray-500 text-xs select-none">
+          Unités: glisser | Sorts/Rituels: cliquer
+        </div>
+      )}
       <div className="flex items-end justify-center gap-2 min-h-[110px] py-1 flex-wrap">
         {player.hand.map((card, i) => {
           const playable = isActive && player.energy >= card.cost;

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -14,6 +14,8 @@ export type SelectionMode =
 interface GameStore {
   gameState: GameState;
   selection: SelectionMode;
+  uiToast: string | null;
+  uiLog: string[];
   p1Faction: 'orisha' | 'zulu';
   p2Faction: 'orisha' | 'zulu';
   screen: 'faction_select' | 'mulligan' | 'hotseat' | 'game' | 'gameover';
@@ -22,12 +24,16 @@ interface GameStore {
   startGame: (p1: 'orisha' | 'zulu', p2: 'orisha' | 'zulu') => void;
   dispatch: (action: GameAction) => void;
   setSelection: (mode: SelectionMode) => void;
+  pushUiFeedback: (message: string) => void;
+  clearUiToast: () => void;
   confirmHotSeat: () => void;
 }
 
 export const useGameStore = create<GameStore>((set, get) => ({
   gameState: initialGameState('orisha', 'zulu'),
   selection: { kind: 'none' },
+  uiToast: null,
+  uiLog: [],
   p1Faction: 'orisha',
   p2Faction: 'zulu',
   screen: 'faction_select',
@@ -61,6 +67,15 @@ export const useGameStore = create<GameStore>((set, get) => ({
   },
 
   setSelection: (mode) => set({ selection: mode }),
+
+  pushUiFeedback: (message) => {
+    set(state => ({
+      uiToast: message,
+      uiLog: [...state.uiLog, message].slice(-80),
+    }));
+  },
+
+  clearUiToast: () => set({ uiToast: null }),
 
   confirmHotSeat: () => {
     set({ screen: 'game', hotSeatPending: null });

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -41,7 +41,15 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   startGame: (p1, p2) => {
     const state = initialGameState(p1, p2);
-    set({ gameState: state, p1Faction: p1, p2Faction: p2, screen: 'mulligan', selection: { kind: 'none' } });
+    set({
+      gameState: state,
+      p1Faction: p1,
+      p2Faction: p2,
+      screen: 'mulligan',
+      selection: { kind: 'none' },
+      uiToast: null,
+      uiLog: [],
+    });
   },
 
   dispatch: (action) => {


### PR DESCRIPTION
## Summary
- ajoute un système de feedback UI global via le store (`uiToast`, `uiLog`) pour expliquer pourquoi une carte ne peut pas être jouée
- affiche un toast animé global sur le board pour les actions refusées (pas le tour actif, énergie insuffisante, action indisponible)
- journalise ces feedbacks dans `GameLog` avec des entrées `[ui]` pour garder une trace explicite côté joueur

## Test plan
- [ ] En tour adverse, tenter de jouer une carte depuis la main active -> toast "Ce n’est pas ton tour." + entrée `[ui]` dans le log
- [ ] Avec énergie insuffisante, tenter de jouer une carte -> toast "Énergie insuffisante: X/Y." + entrée `[ui]`
- [ ] Vérifier que le toast disparaît automatiquement après ~2.2s
- [ ] Vérifier que le gameplay existant reste identique: unités glissées vers le plateau, sorts/rituels joués au clic

Made with [Cursor](https://cursor.com)