### PR TITLE
feat(workflow): Phase 2 — cross-review-router + branch protection doc

### DIFF
--- a/.github/workflows/cross-review-router.yml
+++ b/.github/workflows/cross-review-router.yml
@@ -1,0 +1,168 @@
+name: Cross-review Router
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+    branches:
+      - "**"
+
+permissions:
+  pull-requests: write
+  contents: read
+  issues: write
+
+jobs:
+  # ───────────────────────────────────────────────────────────────────────────
+  # Job 1 — Détecte l'auteur depuis le nom de branche et pose le label author:*
+  # ───────────────────────────────────────────────────────────────────────────
+  detect-author:
+    runs-on: ubuntu-latest
+    outputs:
+      author: ${{ steps.detect.outputs.author }}
+    steps:
+      - name: Detect author from branch name and apply label
+        id: detect
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const prNumber = context.payload.pull_request.number;
+
+            async function hasLabel(label) {
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+              });
+              return labels.some(l => l.name === label);
+            }
+
+            async function addLabel(label) {
+              if (await hasLabel(label)) {
+                console.log(`Label "${label}" already present — skipping.`);
+                return;
+              }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: [label],
+              });
+              console.log(`Label "${label}" applied.`);
+            }
+
+            if (/^feature\/claude\//.test(branch)) {
+              await addLabel('author:claude');
+              core.setOutput('author', 'claude');
+            } else if (/^feature\/cursor\//.test(branch)) {
+              await addLabel('author:cursor');
+              core.setOutput('author', 'cursor');
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: '❌ Branche hors convention. Format attendu : `feature/{claude,cursor}/<slug>`. Voir docs/CROSS_REVIEW_CONVENTIONS.md §2.',
+              });
+              core.setFailed(`Branch "${branch}" does not follow naming convention feature/{claude,cursor}/<slug>.`);
+            }
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Job 2 — Poste le commentaire de routing (idempotent — une seule fois)
+  # ───────────────────────────────────────────────────────────────────────────
+  post-routing-comment:
+    needs: detect-author
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post routing comment (idempotent)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = '${{ needs.detect-author.outputs.author }}';
+            const adversaire = author === 'claude' ? 'cursor' : 'claude';
+            const prNumber = context.payload.pull_request.number;
+            const marker = '<!-- cross-review-router -->';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            if (comments.some(c => c.body.startsWith(marker))) {
+              console.log('Routing comment already posted — skipping.');
+              return;
+            }
+
+            const body = [
+              marker,
+              '## Cross-review routing',
+              '',
+              `**Provenance** : author:${author}`,
+              '',
+              '**Reviewers attendus** :',
+              `- Dev Reviewer adverse → label \`review:${adversaire}-approved\``,
+              `- QA Challenger adverse → balise \`<!-- challenger-verdict:start -->qa-confirmed<!-- challenger-verdict:end -->\` puis label \`verdict:qa-confirmed\``,
+              '',
+              'Cette PR ne pourra pas être mergée tant que :',
+              '- [ ] CI `PR Checks` verte',
+              `- [ ] Label \`review:${adversaire}-approved\` posé`,
+              '- [ ] Label `verdict:qa-confirmed` (ou `verdict:qa-passed` minimum) posé',
+              '',
+              'Voir docs/CROSS_REVIEW_CONVENTIONS.md §3.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+            console.log('Routing comment posted.');
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Job 3 — Status check bloquant : cross-review complète ?
+  # S'exécute à chaque labeled/unlabeled pour se mettre à jour.
+  # ───────────────────────────────────────────────────────────────────────────
+  cross-review-approved:
+    needs: detect-author
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check cross-review labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const labelNames = pr.labels.map(l => l.name);
+
+            const isClaudePR = labelNames.includes('author:claude');
+            const isCursorPR = labelNames.includes('author:cursor');
+
+            if (!isClaudePR && !isCursorPR) {
+              core.setFailed('Label author:claude ou author:cursor manquant — impossible de déterminer le reviewer adverse.');
+              return;
+            }
+
+            const reviewLabel = isClaudePR ? 'review:cursor-approved' : 'review:claude-approved';
+            const qaLabels = ['verdict:qa-confirmed', 'verdict:qa-passed', 'verdict:qa-passed-with-risks'];
+
+            const hasReview = labelNames.includes(reviewLabel);
+            const hasQA = qaLabels.some(l => labelNames.includes(l));
+
+            if (!hasReview || !hasQA) {
+              const missing = [];
+              if (!hasReview) missing.push(`\`${reviewLabel}\``);
+              if (!hasQA) missing.push('un verdict QA (`verdict:qa-confirmed` / `verdict:qa-passed` / `verdict:qa-passed-with-risks`)');
+              core.setFailed(`Cross-review incomplete — labels manquants : ${missing.join(', ')}. Voir le commentaire de routing.`);
+            } else {
+              console.log('Cross-review complete ✅');
+            }

--- a/.github/workflows/cross-review-router.yml
+++ b/.github/workflows/cross-review-router.yml
@@ -11,6 +11,13 @@ permissions:
   contents: read
   issues: write
 
+# Serialize runs per PR to prevent race conditions on comment idempotence.
+# cancel-in-progress: false ensures all runs complete (the second run will
+# find the marker and skip posting a duplicate comment).
+concurrency:
+  group: cross-review-router-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   # ───────────────────────────────────────────────────────────────────────────
   # Job 1 — Détecte l'auteur depuis le nom de branche et pose le label author:*

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,67 @@
+# Branch Protection — `develop`
+
+> Guide d'activation pour le PO. La branch protection rend le workflow `cross-review-router` **bloquant**.
+> Tant qu'elle n'est pas activée, les status checks sont purement déclaratifs.
+
+---
+
+## Pourquoi l'activer
+
+Sans branch protection, n'importe qui peut merger une PR sans cross-review ni CI verte.
+Avec, GitHub bloque automatiquement le bouton "Merge" jusqu'à ce que les checks requis passent.
+
+---
+
+## Étapes (UI GitHub)
+
+1. Aller sur **Settings** → **Branches** → **Add branch protection rule**
+
+2. **Branch name pattern** : `develop`
+
+3. Cocher les options suivantes :
+
+   ### Require a pull request before merging
+   - ☑ Require a pull request before merging
+   - "Required number of approvals" : laisser à `0` pour l'instant (les labels remplacent l'approval)
+
+   ### Require status checks to pass before merging
+   - ☑ Require status checks to pass before merging
+   - ☑ Require branches to be up to date before merging
+   - **Required checks** (chercher dans la liste après un premier run du workflow) :
+     - `lint-test-build` (workflow `PR Checks`)
+     - `cross-review-approved` (workflow `Cross-review Router`)
+
+   ### Require conversation resolution before merging
+   - ☑ Require conversation resolution before merging
+
+   ### Require linear history
+   - ☑ Require linear history *(évite les merge commits parasites)*
+
+   ### Restrictions
+   - ☑ Do not allow bypassing the above settings *(s'applique à tout le monde, y compris admins)*
+
+4. Cliquer **Create** (ou **Save changes** si la règle existe déjà).
+
+---
+
+## Note sur les required checks
+
+Les checks n'apparaissent dans la liste GitHub qu'**après au moins un run** du workflow concerné.
+Si `cross-review-approved` n'est pas dans la liste, ouvrir une PR test sur `feature/claude/test-*`,
+attendre que le workflow tourne, puis revenir ici pour l'ajouter.
+
+---
+
+## Ce que ça bloque concrètement
+
+| Situation | Résultat avec protection active |
+|---|---|
+| PR sans `author:*` | `cross-review-approved` rouge → merge bloqué |
+| PR sans `review:<adverse>-approved` | `cross-review-approved` rouge → merge bloqué |
+| PR sans verdict QA | `cross-review-approved` rouge → merge bloqué |
+| CI rouge (`lint-test-build`) | `lint-test-build` rouge → merge bloqué |
+| Tous les checks verts | Merge autorisé |
+
+---
+
+*Activer dès que le premier cycle complet Claude↔Cursor est terminé (fin Sprint 01 ou avant).*

--- a/docs/CROSS_REVIEW_CONVENTIONS.md
+++ b/docs/CROSS_REVIEW_CONVENTIONS.md
@@ -118,8 +118,9 @@ Côté Cursor, le prompt `.cursor/prompts/pm-readonly.md` (créé en Phase 1) n'
    └─ Crée feature/claude/<slug> ou feature/cursor/<slug>
    └─ Implémente, push
 3. PR ouverte
-   └─ Auto-label author:* (Phase 2) ou manuel
-   └─ Cross-review-router assigne le reviewer adverse
+   └─ Auto-label author:* via `cross-review-router.yml` (branch name → label)
+   └─ Commentaire de routing posé automatiquement avec les reviewers attendus
+   └─ Status check `cross-review-approved` activé (bloquant si branch protection activée — voir `docs/BRANCH_PROTECTION.md`)
 4. Reviewer adverse audite le diff
    └─ Pose review:<reviewer>-approved ou review:changes-requested
 5. QA initial (Claude ou Cursor selon convention de l'équipe)
@@ -139,7 +140,7 @@ Côté Cursor, le prompt `.cursor/prompts/pm-readonly.md` (créé en Phase 1) n'
 |---|---|---|
 | 0 — Conventions | Labels, branches, CLAUDE.md, PR template, ce doc | ✅ Implémentée |
 | 1 — Symétrie Cursor | `.cursor/prompts/dev-reviewer-cursor.md`, `qa-challenger-cursor.md`, `pm-readonly.md` (remplace l'ancien `pm-agent.md` Cursor) | ✅ Implémentée |
-| 2 — Routage auto | Workflow `cross-review-router.yml` + branch protection | ⏳ À faire |
+| 2 — Routage auto | Workflow `cross-review-router.yml` + branch protection | ✅ Implémentée |
 | 3 — Verdicts parsés | Workflow `qa-verdict-parser.yml` + `docs/qa-history.md` | ⏳ À faire |
 | 4 — Tests adversariaux | Dossier `__tests__/adversarial/{claude,cursor}/` + coverage gate | ⏳ À faire |
 | 5 — Hooks Claude + dashboard | `.claude/hooks/` symétrique + `docs/CROSS_REVIEW_DASHBOARD.md` | ⏳ À faire |


### PR DESCRIPTION
## Livrables

**1. `.github/workflows/cross-review-router.yml`**
Workflow en 3 jobs declenche sur `pull_request` (opened, reopened, synchronize, labeled, unlabeled) :
- `detect-author` : lit `head.ref`, applique `author:claude` ou `author:cursor` (idempotent), echoue si branche hors convention
- `post-routing-comment` : poste un commentaire avec les reviewers attendus (idempotent via marker HTML)
- `cross-review-approved` : status check bloquant — passe si review adverse + verdict QA presents, sinon `core.setFailed`

**2. `docs/BRANCH_PROTECTION.md`**
Guide PO pour activer la branch protection sur `develop` (required checks : `lint-test-build` + `cross-review-approved`).

**3. `docs/CROSS_REVIEW_CONVENTIONS.md`**
Phase 2 marquee Implementee dans §7. §6 mis a jour (auto-label + status check mentionnes).

## References
- `docs/CROSS_REVIEW_CONVENTIONS.md` §2 (provenance), §3 (routage), §7 (phases)
- `docs/BRANCH_PROTECTION.md` — a activer pour rendre le workflow bloquant

## Review attendue
Cette PR `author:claude` doit etre reviewee cote Cursor par `dev-reviewer-cursor` puis `qa-challenger-cursor`.

Generated with Claude Code