### PR TITLE
chore(infra): Phase 5 — Claude hooks + cross-review dashboard

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/ensure-feature-branch.sh",
+            "filter": "git (commit|push|rebase|merge|cherry-pick|switch|checkout|branch)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/hooks/ensure-feature-branch.sh
+++ b/.claude/hooks/ensure-feature-branch.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Hook Claude — bloque les opérations Git directes sur main/develop et
+# impose le namespace de branche feature/claude/* pour les agents Claude.
+# Voir docs/CROSS_REVIEW_CONVENTIONS.md.
+
+set -euo pipefail
+
+if ! command -v git >/dev/null 2>&1; then
+  exit 0
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+
+if [[ -z "$branch" || "$branch" == "HEAD" ]]; then
+  exit 0
+fi
+
+# 1. Interdire les opérations sur les branches protégées
+if [[ "$branch" == "main" || "$branch" == "master" || "$branch" == "develop" ]]; then
+  echo "❌ Travail bloqué : pas d'opération Git directe sur main/master/develop." >&2
+  echo "   Crée une branche feature/claude/<slug> avant de continuer." >&2
+  exit 1
+fi
+
+# 2. Rejeter les branches Cursor (réservées à l'autre camp)
+if [[ "$branch" =~ ^feature/cursor/ ]]; then
+  echo "❌ Cette branche appartient au camp Cursor." >&2
+  echo "   Claude doit travailler sur feature/claude/<slug>." >&2
+  exit 1
+fi
+
+# 3. Imposer le namespace feature/claude/<slug> (kebab-case)
+if [[ ! "$branch" =~ ^feature/claude/[a-z0-9][a-z0-9-]*$ ]]; then
+  echo "❌ Format de branche invalide : '$branch'" >&2
+  echo "   Attendu : feature/claude/<slug>  (slug = lettres minuscules, chiffres, tirets)" >&2
+  exit 1
+fi
+
+# OK — silencieux sur succès
+exit 0

--- a/.github/workflows/dashboard-refresh.yml
+++ b/.github/workflows/dashboard-refresh.yml
@@ -1,0 +1,46 @@
+name: Dashboard refresh
+
+on:
+  schedule:
+    - cron: "0 6 * * *"  # tous les jours à 06:00 UTC
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  refresh:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate dashboard
+        run: node scripts/generate-dashboard.mjs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit dashboard if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/CROSS_REVIEW_DASHBOARD.md
+          git diff --staged --quiet || git commit -m "chore(dashboard): refresh cross-review dashboard [skip ci]"
+          git push

--- a/docs/CROSS_REVIEW_CONVENTIONS.md
+++ b/docs/CROSS_REVIEW_CONVENTIONS.md
@@ -149,7 +149,7 @@ Côté Cursor, le prompt `.cursor/prompts/pm-readonly.md` (créé en Phase 1) n'
 | 2 — Routage auto | Workflow `cross-review-router.yml` + branch protection | ✅ Implémentée |
 | 3 — Verdicts parsés | Workflow `qa-verdict-parser.yml` + `docs/qa-history.md` | ✅ Implémentée |
 | 4 — Tests adversariaux | Dossier `__tests__/adversarial/{claude,cursor}/` + coverage gate | ✅ Implémentée |
-| 5 — Hooks Claude + dashboard | `.claude/hooks/` symétrique + `docs/CROSS_REVIEW_DASHBOARD.md` | ⏳ À faire |
+| 5 — Hooks Claude + dashboard | `.claude/hooks/` symétrique + `docs/CROSS_REVIEW_DASHBOARD.md` | ✅ Implémentée |
 
 ---
 
@@ -161,7 +161,7 @@ Côté Cursor, le prompt `.cursor/prompts/pm-readonly.md` (créé en Phase 1) n'
 | 3 boucles `qa-blocked` consécutives | Escalade au PO (Yans) |
 | Reviewer adverse silencieux > 48h | Le PM peut forcer le merge en signant manuellement le label adverse, avec note dans `docs/SPRINT_XX.md` |
 | PR sans label `author:*` | CI bloque le merge (Phase 2) |
-| Branche hors namespace | Hook bloque les ops Git (Phase 0 ✅ pour Cursor) |
+| Branche hors namespace | Hook bloque les ops Git (Phase 0 ✅ Cursor, Phase 5 ✅ Claude) |
 | `qa-confirmed` posé sans test adversarial ni justification | PM Claude rouvre le verdict, demande au Challenger de compléter |
 | Coverage statements < 70 % | CI bloque le merge automatiquement |
 
@@ -211,7 +211,44 @@ node scripts/check-coverage.mjs
 
 ---
 
-## 11. Glossaire rapide
+## 11. Dashboard et hooks Claude
+
+### Dashboard cross-review
+
+`docs/CROSS_REVIEW_DASHBOARD.md` est le tableau de bord du dispositif. Il agrège :
+- Activité par camp (PR ouvertes, mergées, verdicts posés, tests adversariaux)
+- État temps réel des PR en cours (CI, review adverse, verdict QA, bloqueurs)
+- Historique des 10 derniers verdicts (`docs/qa-history.md`)
+- Coverage actuel (`coverage/coverage-summary.json`)
+- Désaccords ouverts (`verdict:qa-escalate` sans résolution)
+- Santé globale du dispositif
+
+**Usage PO** : relire le dashboard une fois par sprint pour détecter les verdicts en attente > 48h
+(relancer l'agent concerné) et les désaccords ouverts (demander arbitrage au PM Claude).
+
+**Refresh local :**
+```bash
+node scripts/generate-dashboard.mjs
+```
+
+**Refresh automatique :** workflow `dashboard-refresh.yml` — tous les jours à 06:00 UTC + à chaque
+PR mergée sur `develop`.
+
+### Hooks Claude
+
+`.claude/hooks/ensure-feature-branch.sh` + `.claude/hooks.json` assurent, côté Claude, la même
+protection que `.cursor/hooks/` côté Cursor :
+
+| Situation | Comportement |
+|---|---|
+| Branche `main`/`develop` | exit 1 — commit bloqué |
+| Branche `feature/cursor/*` | exit 1 — camp adverse |
+| Branche hors `feature/claude/<slug>` | exit 1 — format invalide |
+| Branche `feature/claude/<slug>` valide | exit 0 silencieux |
+
+---
+
+## 12. Glossaire rapide
 
 - **Dev Reviewer** : agent qui audite le code de l'autre camp avant QA. Verdict en commentaire structuré.
 - **QA Challenger** : agent qui produit un second avis indépendant après le QA initial.

--- a/docs/CROSS_REVIEW_DASHBOARD.md
+++ b/docs/CROSS_REVIEW_DASHBOARD.md
@@ -1,0 +1,56 @@
+# Cross-review Dashboard — Sankofa POC
+
+> Généré par `scripts/generate-dashboard.mjs`. Source : GitHub API + `docs/qa-history.md`.
+> Dernière mise à jour : 2026-04-27T18:08:51.633Z
+
+---
+
+## 1. Activité par camp (30 derniers jours)
+
+| Camp | PR ouvertes | PR mergées | Verdicts QA posés | Tests adversariaux ajoutés |
+|---|---|---|---|---|
+| Claude | 0 | 0 | 2 | 0 |
+| Cursor | 0 | 0 | 0 | 0 |
+
+---
+
+## 2. PR en cours (état temps réel)
+
+| # | Titre | Auteur | CI | Reviewer adverse | Verdict QA | Bloqueurs |
+|---|---|---|---|---|---|---|
+| — | Aucune PR ouverte | — | — | — | — | — |
+
+---
+
+## 3. Verdicts récents (10 derniers)
+
+| Date (UTC) | PR | Agent | Verdict |
+|---|---|---|---|
+| 2026-04-27T12:56:47.975Z | #16 | challenger | qa-confirmed |
+| 2026-04-27T12:51:03.087Z | #16 | claude | qa-pending |
+
+---
+
+## 4. Coverage actuel
+
+| Métrique | Valeur | Seuil | Statut |
+|---|---|---|---|
+| — | N/A | — | Lancer `npm run test:coverage` |
+
+---
+
+## 5. Désaccords ouverts (verdict:qa-escalate sans résolution)
+
+| PR | Date escalade | Raison | Action attendue |
+|---|---|---|---|
+| — | — | — | Aucun désaccord ouvert |
+
+---
+
+## 6. Santé du dispositif
+
+- ✅ Aucun verdict pending > 48h 
+- ✅ Workflow `cross-review-router` actif
+- ✅ Workflow `qa-verdict-parser` actif
+- ✅ Coverage gate actif (seuil statements ≥ 70 %)
+- ⏳ Branch protection `develop` — activer manuellement (voir `docs/BRANCH_PROTECTION.md`)

--- a/scripts/generate-dashboard.mjs
+++ b/scripts/generate-dashboard.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Usage : node scripts/generate-dashboard.mjs
+ * Pré-requis : gh CLI authentifié, Node 18+
+ * Lancement automatique : workflow `.github/workflows/dashboard-refresh.yml`
+ *
+ * Génère docs/CROSS_REVIEW_DASHBOARD.md depuis GitHub API + qa-history.md + coverage.
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function gh(args) {
+  try {
+    return JSON.parse(execSync(`gh ${args}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }));
+  } catch {
+    return null;
+  }
+}
+
+function ghText(args) {
+  try {
+    return execSync(`gh ${args}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  } catch {
+    return '';
+  }
+}
+
+const now = new Date().toISOString();
+
+// ── 1. PR ouvertes ──────────────────────────────────────────────────────────
+const openPRs = gh('pr list --state open --json number,title,labels,headRefName,statusCheckRollup,author --limit 30') ?? [];
+
+// ── 2. PR mergées (30 derniers jours) ──────────────────────────────────────
+const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+const mergedPRs = gh(`pr list --state merged --search "merged:>=${since}" --json number,title,labels,author --limit 50`) ?? [];
+
+// ── 3. qa-history.md ──────────────────────────────────────────────────────
+const historyPath = resolve(root, 'docs', 'qa-history.md');
+let recentVerdicts = [];
+if (existsSync(historyPath)) {
+  const lines = readFileSync(historyPath, 'utf8')
+    .split('\n')
+    .filter(l => l.startsWith('|') && !l.includes('Date (UTC)') && !l.includes('---'));
+  recentVerdicts = lines.slice(-10).reverse();
+}
+
+// ── 4. Coverage ───────────────────────────────────────────────────────────
+const summaryPath = resolve(root, 'coverage', 'coverage-summary.json');
+let coverageRows = '';
+if (existsSync(summaryPath)) {
+  const s = JSON.parse(readFileSync(summaryPath, 'utf8')).total;
+  const THRESHOLDS = { statements: 70, functions: 70, branches: 65, lines: 70 };
+  coverageRows = ['statements', 'functions', 'branches', 'lines'].map(m => {
+    const pct = s[m]?.pct ?? 0;
+    const thr = THRESHOLDS[m];
+    const icon = pct >= thr ? '✅' : '❌';
+    return `| ${m} | ${pct.toFixed(1)} % | ${thr} % | ${icon} |`;
+  }).join('\n');
+} else {
+  coverageRows = '| — | N/A | — | Lancer `npm run test:coverage` |';
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+function labelNames(pr) {
+  return (pr.labels ?? []).map(l => l.name);
+}
+
+function authorCamp(pr) {
+  const ls = labelNames(pr);
+  if (ls.includes('author:claude')) return 'claude';
+  if (ls.includes('author:cursor')) return 'cursor';
+  const branch = pr.headRefName ?? '';
+  if (branch.startsWith('feature/claude/')) return 'claude';
+  if (branch.startsWith('feature/cursor/')) return 'cursor';
+  return '?';
+}
+
+function ciStatus(pr) {
+  const checks = pr.statusCheckRollup ?? [];
+  if (!checks.length) return '⏳';
+  const all = checks.every(c => c.conclusion === 'SUCCESS' || c.status === 'SUCCESS');
+  const any = checks.some(c => c.conclusion === 'FAILURE' || c.conclusion === 'TIMED_OUT');
+  if (any) return '❌';
+  if (all) return '✅';
+  return '🔄';
+}
+
+function verdictLabel(pr) {
+  const ls = labelNames(pr);
+  const v = ['verdict:qa-confirmed', 'verdict:qa-passed', 'verdict:qa-passed-with-risks',
+             'verdict:qa-blocked', 'verdict:qa-escalate'].find(l => ls.includes(l));
+  return v ? `\`${v}\`` : '⏳ pending';
+}
+
+function reviewLabel(pr, camp) {
+  const ls = labelNames(pr);
+  const adverse = camp === 'claude' ? 'cursor' : 'claude';
+  if (ls.includes(`review:${adverse}-approved`)) return `\`review:${adverse}-approved\``;
+  if (ls.includes('review:changes-requested')) return '`changes-requested`';
+  return '⏳ pending';
+}
+
+function blockers(pr, camp) {
+  const ls = labelNames(pr);
+  const issues = [];
+  const adverse = camp === 'claude' ? 'cursor' : 'claude';
+  if (!ls.includes(`review:${adverse}-approved`) && !ls.includes('review:changes-requested')) issues.push('review manquante');
+  if (!ls.some(l => l.startsWith('verdict:'))) issues.push('verdict QA manquant');
+  if (ciStatus(pr) === '❌') issues.push('CI rouge');
+  return issues.length ? issues.join(', ') : '—';
+}
+
+// ── Activité par camp ──────────────────────────────────────────────────────
+const stats = { claude: { open: 0, merged: 0 }, cursor: { open: 0, merged: 0 } };
+openPRs.forEach(pr => { const c = authorCamp(pr); if (c !== '?') stats[c].open++; });
+mergedPRs.forEach(pr => { const c = authorCamp(pr); if (c !== '?') stats[c].merged++; });
+
+const qaHistory = existsSync(historyPath)
+  ? readFileSync(historyPath, 'utf8').split('\n').filter(l => l.startsWith('|') && !l.includes('Date (UTC)'))
+  : [];
+const claudeVerdicts = qaHistory.filter(l => l.includes('| claude |') || l.includes('| challenger |')).length;
+const cursorVerdicts = qaHistory.filter(l => l.includes('| cursor |')).length;
+
+const adversarialBase = resolve(root, 'src', 'engine', '__tests__', 'adversarial');
+function countTests(camp) {
+  try {
+    return parseInt(execSync(`find "${adversarialBase}/${camp}" -name "*.test.ts" | wc -l`, { encoding: 'utf8' }).trim(), 10) || 0;
+  } catch { return 0; }
+}
+
+// ── PR en cours ───────────────────────────────────────────────────────────
+const prRows = openPRs.length
+  ? openPRs.map(pr => {
+      const camp = authorCamp(pr);
+      const ci = ciStatus(pr);
+      const review = reviewLabel(pr, camp);
+      const verdict = verdictLabel(pr);
+      const block = blockers(pr, camp);
+      return `| #${pr.number} | ${pr.title.slice(0, 40)} | ${camp} | ${ci} | ${review} | ${verdict} | ${block} |`;
+    }).join('\n')
+  : '| — | Aucune PR ouverte | — | — | — | — | — |';
+
+// ── Désaccords ouverts ────────────────────────────────────────────────────
+const escalated = openPRs.filter(pr => labelNames(pr).includes('verdict:qa-escalate'));
+const escalateRows = escalated.length
+  ? escalated.map(pr => `| #${pr.number} | ${now.slice(0, 10)} | \`verdict:qa-escalate\` | Arbitrage PM Claude requis |`).join('\n')
+  : '| — | — | — | Aucun désaccord ouvert |';
+
+// ── Santé ─────────────────────────────────────────────────────────────────
+const pendingOver48h = openPRs.filter(pr => {
+  const ls = labelNames(pr);
+  return !ls.some(l => l.startsWith('verdict:')) && pr.createdAt
+    && (Date.now() - new Date(pr.createdAt).getTime()) > 48 * 60 * 60 * 1000;
+}).length;
+
+// ── Assemblage du dashboard ───────────────────────────────────────────────
+const dashboard = `# Cross-review Dashboard — Sankofa POC
+
+> Généré par \`scripts/generate-dashboard.mjs\`. Source : GitHub API + \`docs/qa-history.md\`.
+> Dernière mise à jour : ${now}
+
+---
+
+## 1. Activité par camp (30 derniers jours)
+
+| Camp | PR ouvertes | PR mergées | Verdicts QA posés | Tests adversariaux ajoutés |
+|---|---|---|---|---|
+| Claude | ${stats.claude.open} | ${stats.claude.merged} | ${claudeVerdicts} | ${countTests('claude')} |
+| Cursor | ${stats.cursor.open} | ${stats.cursor.merged} | ${cursorVerdicts} | ${countTests('cursor')} |
+
+---
+
+## 2. PR en cours (état temps réel)
+
+| # | Titre | Auteur | CI | Reviewer adverse | Verdict QA | Bloqueurs |
+|---|---|---|---|---|---|---|
+${prRows}
+
+---
+
+## 3. Verdicts récents (10 derniers)
+
+| Date (UTC) | PR | Agent | Verdict |
+|---|---|---|---|
+${recentVerdicts.length ? recentVerdicts.join('\n') : '| — | — | — | Aucun verdict enregistré |'}
+
+---
+
+## 4. Coverage actuel
+
+| Métrique | Valeur | Seuil | Statut |
+|---|---|---|---|
+${coverageRows}
+
+---
+
+## 5. Désaccords ouverts (verdict:qa-escalate sans résolution)
+
+| PR | Date escalade | Raison | Action attendue |
+|---|---|---|---|
+${escalateRows}
+
+---
+
+## 6. Santé du dispositif
+
+- ${pendingOver48h === 0 ? '✅' : '❌'} Aucun verdict pending > 48h ${pendingOver48h > 0 ? `(${pendingOver48h} PR concernée(s))` : ''}
+- ✅ Workflow \`cross-review-router\` actif
+- ✅ Workflow \`qa-verdict-parser\` actif
+- ✅ Coverage gate actif (seuil statements ≥ 70 %)
+- ⏳ Branch protection \`develop\` — activer manuellement (voir \`docs/BRANCH_PROTECTION.md\`)
+`;
+
+// ── Écriture idempotente (ne commit que si contenu hors timestamp a changé) ──
+const dashboardPath = resolve(root, 'docs', 'CROSS_REVIEW_DASHBOARD.md');
+const stripTimestamp = s => s.replace(/Dernière mise à jour : .+/, 'Dernière mise à jour : __TS__');
+const newHash = createHash('sha256').update(stripTimestamp(dashboard)).digest('hex');
+
+if (existsSync(dashboardPath)) {
+  const existing = readFileSync(dashboardPath, 'utf8');
+  const oldHash = createHash('sha256').update(stripTimestamp(existing)).digest('hex');
+  if (oldHash === newHash) {
+    console.log('Dashboard inchangé (hors timestamp) — aucune écriture.');
+    process.exit(0);
+  }
+}
+
+writeFileSync(dashboardPath, dashboard, 'utf8');
+console.log(`✅ Dashboard généré : docs/CROSS_REVIEW_DASHBOARD.md`);


### PR DESCRIPTION
## Phase 5 — Hooks Claude symétriques + dashboard cross-review

### Provenance
author:claude

### Livrables
- `.claude/hooks/ensure-feature-branch.sh` — symétrique du hook Cursor, bloque commit/push hors `feature/claude/*`
- `.claude/hooks.json` — déclaration PreToolUse pour Claude Code
- `scripts/generate-dashboard.mjs` — génère le dashboard depuis GitHub API + qa-history + coverage
- `docs/CROSS_REVIEW_DASHBOARD.md` — premier snapshot (activité, PR en cours, verdicts, coverage, santé)
- `.github/workflows/dashboard-refresh.yml` — refresh quotidien 06:00 UTC + on PR merged develop
- `docs/CROSS_REVIEW_CONVENTIONS.md` — §7 Phase 5 ✅, §11 Dashboard et hooks, §12 Glossaire

### Tests locaux
```bash
# Hook
bash .claude/hooks/ensure-feature-branch.sh  # exit 0 sur feature/claude/*
# Dashboard
node scripts/generate-dashboard.mjs          # écrit docs/CROSS_REVIEW_DASHBOARD.md
```

### Verdict QA initial
<!-- verdict:start -->
qa-pending
<!-- verdict:end -->

### Cross-review checklist
- [ ] CI verte
- [ ] Dev Reviewer Cursor : audit attendu
- [ ] QA Cursor : verdict attendu
