### PR TITLE
docs(pm): sprint 02 planning — M2 clôture + M3 démarrage

### DIFF
--- a/docs/PM_RAPPORT_2026-04-27.md
+++ b/docs/PM_RAPPORT_2026-04-27.md
@@ -1,0 +1,90 @@
+# Rapport PM — 2026-04-27
+
+**Agent :** Claude PM (`docs/CROSS_REVIEW_CONVENTIONS.md` §5)
+**Sprint clôturé :** Sprint 01 (M1 Engine Core)
+**Sprint ouvert :** Sprint 02 (M2 clôture + M3 démarrage)
+
+---
+
+## 1. Synthèse milestones
+
+| Milestone | Issues ouvertes | Issues closes | PR mergées | Coverage | Statut |
+|---|---|---|---|---|---|
+| M1 — Engine Core | 0 | 7 (#4–#10) | 6 (PRs #1,#3,#7-#10,#15) | stmts 83 % / branches 68 % | 🟢 COMPLÈTE |
+| M2 — UI minimale | 1 (#26) | 9 (#17–#25) | PRs #1, #2 (pre-tracking) | — | 🟡 DERNIER BUG |
+| M3 — Polish + 20 cartes | 4 (#28–#31) | 0 | — | — | 🔴 NON DÉMARRÉ |
+
+---
+
+## 2. Trous identifiés
+
+### M1 — Engine Core
+**Livré** :
+- Moteur complet : 9 actions, 6 sous-systèmes, CLI, 66 tests, 83% statements coverage
+- Tous les types du brief §8 implémentés en strict TypeScript
+
+**Manquant/incomplet** :
+- [bug] `processDeaths` ne déclenche pas les effets `on_death` → deathrattle de Z09 non fonctionnel
+- [bug] `grant_divine_shield_hero` est un no-op dans `reducers.ts` → Z06 ne protège pas le héros
+- [note] Ces deux bugs ont été découverts lors de l'audit M3 ; ils n'ont pas empêché M1 d'être acceptée car aucun test ne couvrait ces cas précis
+
+### M2 — UI minimale
+**Livré** (via PRs #1/#2/#3 mergées 2026-04-26, avant création formelle des tickets) :
+- Zustand store connecté à `applyAction` (`src/store/gameStore.ts`)
+- Tous les composants : Board, Card, Hand, Altar, RitualZone, HeroPanel, GameLog, MulliganModal
+- Drag & drop dnd-kit pour invoquer les unités
+- Click-to-target pour attaques et sorts
+- Bouton fin de tour + transition hot-seat
+- Écran de victoire, FactionSelect
+
+**Manquant/incomplet** :
+- [bug] Sangoma Guérisseuse (Z05) — `scope: 'random_enemy'` au lieu de `random_ally` dans `cards.json`, et la logique `heal` dans `resolveEffect` ne cible pas les unités alliées → issue #26 ouverte
+
+### M3 — Polish + 20 cartes
+**Livré** : rien (sprint non démarré)
+
+**Manquant** (4 issues créées) :
+- [fix/engine] Deathrattle `on_death` + `heroDivineShield` — issue #28
+- [feat/ux] Animations Framer Motion — issue #29
+- [docs] README — issue #30
+- [feat/ux+chore] Polish FactionSelect + déploiement Vercel — issue #31
+
+---
+
+## 3. Issues créées dans ce passage
+
+| # | Titre | Milestone | Size | Assignation prévue |
+|---|---|---|---|---|
+| #28 | Effets moteur manquants : deathrattle on_death + grant_divine_shield_hero | M3 | M | Claude |
+| #29 | Animations Framer Motion — apparition, mort, dégâts | M3 | M | Cursor |
+| #30 | README — install, run, play | M3 | S | Claude ou Cursor |
+| #31 | Polish écran d'accueil + déploiement Vercel | M3 | S | Cursor |
+
+Issues closes dans ce passage : #17, #18, #19, #20, #21, #22, #23, #24, #25 (code déjà livré).
+
+PR ouverte : [#32 — docs(pm): sprint 02 planning](https://github.com/yans40/sankofa-poc/pull/32)
+
+---
+
+## 4. Questions ouvertes au PO
+
+| Question | Statut | Impact |
+|---|---|---|
+| Q-004 — Plateforme de déploiement (Vercel vs Netlify) | 🔴 OUVERTE | Bloque #31 — par défaut Vercel si pas de réponse avant fin Sprint 02 |
+| Q-005 — Visibilité du repo (public vs privé) | 🔴 OUVERTE | Bloque tout déploiement public |
+
+---
+
+## 5. Recommandations
+
+1. **Démarrer #26 immédiatement** (Sangoma fix) — c'est le seul ticket qui bloque la clôture de M2. Simple correction dans `cards.json` + extension de `resolveEffect` pour le scope `random_ally` sur les unités.
+
+2. **#28 en parallèle de #29** — les deux sont indépendants. Claude prend le moteur, Cursor prend les animations.
+
+3. **Trancher Q-004 et Q-005 avant fin Sprint 02** — sans URL publique, la démo de pitch est impossible. Recommandation : Vercel, repo privé avec preview link partageable.
+
+4. **Audit des 20 cartes en M3** — au-delà des bugs identifiés (#26, #28), faire un passage complet sur `cards.json` pour s'assurer que tous les effets sont correctement sérialisés avant les animations.
+
+---
+
+*Rapport généré par l'agent PM Claude — 2026-04-27.*

--- a/docs/QUESTIONS.md
+++ b/docs/QUESTIONS.md
@@ -31,7 +31,7 @@ Chaque question suit ce gabarit :
 ## Questions héritées du brief (à trancher avant Milestone 1)
 
 ### Q-001 — Hot-seat : protection visuelle entre joueurs ?
-**Statut :** 🟡 EN DISCUSSION
+**Statut :** 🟢 TRANCHÉE
 **Posée par :** PO (dans POC_BRIEF.md §14.1)
 **Contexte :** Quand le tour passe du Joueur 1 au Joueur 2, l'adversaire doit-il jamais voir ma main ?
 **Options envisagées :**

--- a/docs/SPRINT_02.md
+++ b/docs/SPRINT_02.md
@@ -1,0 +1,120 @@
+# Sprint 02 — M2 Clôture + M3 Démarrage (du 2026-04-27 au 2026-05-11)
+
+## Objectif
+
+Clore définitivement M2 (corriger le dernier bug bloquant) et démarrer M3 avec les quatre tâches qui permettront d'avoir un POC présentable en pitch : effets moteur complets, animations, README et déploiement.
+
+---
+
+## Bilan Sprint 01
+
+| Statut | Détail |
+|---|---|
+| ✅ M1 Engine Core | 7 issues closes, 66 tests, 83% coverage, CLI fonctionnel |
+| ✅ M2 UI minimale | Code livré via PRs #1/#2/#3 avant création formelle des tickets — 9 issues closes (#17-#25), 1 bug restant (#26) |
+| ⏳ M3 non démarré | 4 nouvelles issues créées dans ce sprint |
+
+---
+
+## Capacité
+
+- **Claude (Dev + QA)** : 2 tickets visés (#26 bug moteur, #28 effets moteur)
+- **Cursor (Dev + QA)** : 2 tickets visés (#29 animations, #31 polish + déploiement)
+- **Claude ou Cursor** : 1 ticket partageable (#30 README)
+
+---
+
+## Tickets
+
+| # | Titre | Auteur prévu | Size | Milestone | Statut | PR |
+|---|---|---|---|---|---|---|
+| #26 | Fix Sangoma Guérisseuse — cible on_turn_end + heal unit | Claude | S | M2 | open | — |
+| #28 | Effets moteur manquants : deathrattle on_death + grant_divine_shield_hero | Claude | M | M3 | open | — |
+| #29 | Animations Framer Motion — apparition, mort, dégâts | Cursor | M | M3 | open | — |
+| #30 | README — install, run, play | Claude ou Cursor | S | M3 | open | — |
+| #31 | Polish écran d'accueil + déploiement Vercel | Cursor | S | M3 | open | — |
+
+**Ordre de traitement recommandé :**
+
+```
+#26 (M2 bug fix)  →  #28 (moteur)  →  #29 (UI animations, en parallèle de #30)  →  #30 (README)  →  #31 (deploy)
+```
+
+#26 est bloquant pour déclarer M2 complète. #28 peut démarrer dès #26 mergé (réutilise le pattern `random_ally`). #29, #30, #31 peuvent démarrer indépendamment.
+
+---
+
+## Trous identifiés par rapport au brief
+
+### M2 — seul trou restant
+
+**Bug Sangoma Guérisseuse (Z05)** — issue #26 :
+1. `cards.json` : `scope: 'random_enemy'` → devrait être `random_ally`
+2. `reducers.ts` `resolveEffect / heal` : ne gère que le héros — doit gérer une unité `random_ally`
+
+### M3 — trous à traiter dans ce sprint
+
+**Deathrattle non déclenché** — issue #28 :
+- `processDeaths` (`combat.ts`) ne déclenche pas les effets `on_death`
+- Z09 Champion Mzilikazi : token Lancier Zoulou jamais invoqué à la mort
+
+**`grant_divine_shield_hero` no-op** — issue #28 :
+- `resolveEffect` applique `heroAttack: p.heroAttack` (aucun changement)
+- `PlayerState` n'a pas de champ `heroDivineShield`
+- Z06 Bouclier Isihlangu ne protège pas le héros
+
+**Animations manquantes** — issue #29 :
+- Apparition/mort/dégâts instantanés — Framer Motion non intégré
+
+**README absent** — issue #30 :
+- Critère §15 bloquant pour démo et pitch
+
+**Démo non hébergée** — issue #31 :
+- URL publique requise pour pitch + KR5 (< 3s chargement)
+
+---
+
+## Questions ouvertes au PO
+
+| Question | Statut | Action requise |
+|---|---|---|
+| Q-004 — URL déploiement | 🔴 OUVERTE | Décision avant fin Sprint 02 pour pouvoir merge #31 |
+| Q-005 — Visibilité repo | 🔴 OUVERTE | Décision avant déploiement public |
+
+---
+
+## Non-objectifs du Sprint 02
+
+- Cartes M3 non listées dans ce sprint (deck builder, nouvelles factions)
+- Optimisations de performance avancées
+- Tests end-to-end (hors périmètre POC)
+- Internationalisation
+
+---
+
+## Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Z06 Bouclier Isihlangu = type Artefact (brief §4.2 hors scope, mais §10 l'inclut dans les 20 cartes) | Moyen | Traité dans #28 comme `spell` qui donne `heroDivineShield` — conforme à l'esprit du brief |
+| Animations Framer Motion + `AnimatePresence` peuvent créer des glitches sur le state Zustand | Moyen | Cursor devra valider en partie complète avant QA |
+| Q-004 non résolue bloque #31 | Faible | Default = Vercel si pas de réponse PO avant fin sprint |
+
+---
+
+## Définition of Done — Sprint 02
+
+- [ ] #26 mergé sur `develop` (Sangoma fix + tests)
+- [ ] #28 mergé sur `develop` (deathrattle + heroDivineShield + tests)
+- [ ] #29 mergé sur `develop` (animations Framer Motion fonctionnelles)
+- [ ] #30 mergé sur `develop` (README complet)
+- [ ] #31 mergé sur `develop` (deploy live ou PR ready si Q-004 encore ouverte)
+- [ ] Coverage statements ≥ 70 % sur `develop` après #26 + #28
+- [ ] Aucun verdict `qa-escalate` en suspens
+- [ ] `docs/CROSS_REVIEW_DASHBOARD.md` à jour (workflow automatique)
+- [ ] M2 fermée sur GitHub (milestone) dès #26 mergé
+- [ ] `docs/PM_RAPPORT_2026-04-27.md` publié (ce sprint)
+
+---
+
+*Document généré par l'agent PM Claude — 2026-04-27.*

--- a/docs/qa-history.md
+++ b/docs/qa-history.md
@@ -6,3 +6,4 @@
 |---|---|---|---|
 | 2026-04-27T12:51:03.087Z | #16 | claude | qa-pending |
 | 2026-04-27T12:56:47.975Z | #16 | challenger | qa-confirmed |
+| 2026-04-27T18:39:16.307Z | #32 | challenger | qa-confirmed |


### PR DESCRIPTION
## Résumé
- Crée `docs/SPRINT_02.md` : plan du sprint 02 avec 5 tickets (1 M2 bug + 4 M3)
- Passe Q-001 dans `docs/QUESTIONS.md` de 🟡 EN DISCUSSION → 🟢 TRANCHÉE (HotSeatScreen livré)

## Contexte PM
- Issues #17-#25 (M2) closes : code était déjà livré via PRs #1/#2/#3 avant création formelle des tickets
- Issues créées dans ce passage : #26 (déjà existante), #28, #29, #30, #31
- Questions PO ouvertes : Q-004 (plateforme déploiement) et Q-005 (visibilité repo)

## Test plan
- [ ] Vérifier que `docs/SPRINT_02.md` est bien structuré et lisible
- [ ] Vérifier que `docs/QUESTIONS.md` Q-001 est 🟢 TRANCHÉE

<!-- verdict:start -->
qa-pending
<!-- verdict:end -->