### PR TITLE
fix(engine): #26 Sangoma random_ally + heal unit effect

### DIFF
--- a/docs/qa-history.md
+++ b/docs/qa-history.md
@@ -8,3 +8,4 @@
 | 2026-04-27T12:56:47.975Z | #16 | challenger | qa-confirmed |
 | 2026-04-27T18:39:16.307Z | #32 | challenger | qa-confirmed |
 | 2026-04-27T19:24:20.761Z | #33 | challenger | qa-confirmed |
+| 2026-04-27T19:45:27.166Z | #34 | challenger | qa-confirmed |

--- a/src/data/cards.json
+++ b/src/data/cards.json
@@ -247,7 +247,7 @@
       {
         "trigger": "on_turn_end",
         "description": "À la fin de votre tour : soigne une unité alliée de 2 PV",
-        "resolve": { "kind": "heal", "amount": 2, "target": { "scope": "random_enemy" } }
+        "resolve": { "kind": "heal", "amount": 2, "target": { "scope": "random_ally" } }
       }
     ],
     "flavorText": "Ses herbes guérissent les blessures du corps.",

--- a/src/engine/__tests__/adversarial/claude/34-sangoma-heal.test.ts
+++ b/src/engine/__tests__/adversarial/claude/34-sangoma-heal.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Adversarial QA — PR #34 (author:cursor) — Claude QA Challenger
+ * Cases not covered by Cursor's sangoma.test.ts:
+ *   1. Sangoma heals herself when she is the only wounded ally
+ *   2. Cross-player isolation — p1 Sangoma never heals p2 units
+ */
+import { describe, it, expect } from 'vitest';
+import cardsData from '../../../../data/cards.json' assert { type: 'json' };
+import type { Card, GameState, UnitInstance } from '../../../types.js';
+import { initialGameState } from '../../../gameState.js';
+import { applyAction } from '../../../reducers.js';
+
+const allCards = cardsData as Card[];
+
+function startedGame(): GameState {
+  let state = initialGameState('orisha', 'zulu');
+  state = applyAction(state, { type: 'MULLIGAN', playerId: 'p1', cardIndices: [] });
+  state = applyAction(state, { type: 'MULLIGAN', playerId: 'p2', cardIndices: [] });
+  return state;
+}
+
+function makeUnit(
+  instanceId: string,
+  card: Card,
+  currentHealth: number,
+  maxHealth: number,
+  ownerId: 'p1' | 'p2' = 'p1',
+): UnitInstance {
+  return {
+    instanceId,
+    card,
+    currentAttack: card.attack ?? 0,
+    currentHealth,
+    maxHealth,
+    hasAttackedThisTurn: false,
+    justSummoned: false,
+    isSpectral: false,
+    spectralExpiresAtTurn: null,
+    hasDivineShield: false,
+    ownerId,
+  };
+}
+
+const z05 = allCards.find(c => c.id === 'Z05')!;
+const z01 = allCards.find(c => c.id === 'Z01')!;
+
+describe('Adversarial — PR #34 Sangoma heal edge cases', () => {
+  it('Sangoma wounded alone heals herself', () => {
+    // Sangoma is the only unit on p1 battlefield and is wounded.
+    // random_ally should include herself as a valid candidate.
+    let state = startedGame();
+    const sangoma = makeUnit('sangoma-self', z05, 2, 4);
+    state = {
+      ...state,
+      players: {
+        ...state.players,
+        p1: { ...state.players.p1, battlefield: [sangoma] },
+      },
+    };
+    state = applyAction(state, { type: 'END_TURN', playerId: 'p1' });
+    const u = state.players.p1.battlefield.find(x => x.instanceId === 'sangoma-self');
+    expect(u?.currentHealth).toBe(4); // 2 + 2 heal = 4 (== maxHealth)
+  });
+
+  it('cross-player isolation: p1 Sangoma never heals p2 units', () => {
+    // p2 has a wounded unit; p1 Sangoma fires on_turn_end.
+    // p2's unit must remain untouched.
+    let state = startedGame();
+    const sangoma = makeUnit('sangoma-iso', z05, 4, 4);
+    const p2unit = makeUnit('p2-wounded', z01, 1, 3, 'p2');
+    state = {
+      ...state,
+      players: {
+        ...state.players,
+        p1: { ...state.players.p1, battlefield: [sangoma] },
+        p2: { ...state.players.p2, battlefield: [p2unit] },
+      },
+    };
+    state = applyAction(state, { type: 'END_TURN', playerId: 'p1' });
+    const p2u = state.players.p2.battlefield.find(x => x.instanceId === 'p2-wounded');
+    expect(p2u?.currentHealth).toBe(1); // untouched
+  });
+});

--- a/src/engine/__tests__/sangoma.test.ts
+++ b/src/engine/__tests__/sangoma.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import cardsData from '../../data/cards.json' assert { type: 'json' };
+import type { Card, GameState, UnitInstance } from '../types.js';
+import { initialGameState } from '../gameState.js';
+import { applyAction } from '../reducers.js';
+
+const allCards = cardsData as Card[];
+
+function startedGame(): GameState {
+  let state = initialGameState('orisha', 'zulu');
+  state = applyAction(state, { type: 'MULLIGAN', playerId: 'p1', cardIndices: [] });
+  state = applyAction(state, { type: 'MULLIGAN', playerId: 'p2', cardIndices: [] });
+  return state;
+}
+
+function makeUnit(
+  instanceId: string,
+  card: Card,
+  currentHealth: number,
+  maxHealth: number,
+  ownerId: 'p1' | 'p2' = 'p1',
+): UnitInstance {
+  return {
+    instanceId,
+    card,
+    currentAttack: card.attack ?? 0,
+    currentHealth,
+    maxHealth,
+    hasAttackedThisTurn: false,
+    justSummoned: false,
+    isSpectral: false,
+    spectralExpiresAtTurn: null,
+    hasDivineShield: false,
+    ownerId,
+  };
+}
+
+describe('Sangoma Guérisseuse (Z05) — random_ally heal', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const z05 = allCards.find(c => c.id === 'Z05')!;
+  const z01 = allCards.find(c => c.id === 'Z01')!;
+  const z04 = allCards.find(c => c.id === 'Z04')!;
+
+  it('Z05 on_turn_end uses random_ally (issue #26)', () => {
+    const e = z05.effects.find(x => x.trigger === 'on_turn_end');
+    expect(e?.resolve.kind).toBe('heal');
+    if (e?.resolve.kind === 'heal') {
+      expect(e.resolve.target.scope).toBe('random_ally');
+      expect(e.resolve.amount).toBe(2);
+    }
+  });
+
+  it('no wounded ally: end turn leaves full-HP Sangoma unchanged', () => {
+    let state = startedGame();
+    const sangoma = makeUnit('sangoma-1', z05, 4, 4);
+    state = {
+      ...state,
+      players: {
+        ...state.players,
+        p1: { ...state.players.p1, battlefield: [sangoma] },
+      },
+    };
+    state = applyAction(state, { type: 'END_TURN', playerId: 'p1' });
+    const u = state.players.p1.battlefield.find(x => x.instanceId === 'sangoma-1');
+    expect(u?.currentHealth).toBe(4);
+  });
+
+  it('two wounded allies: exactly one receives heal (random)', () => {
+    let state = startedGame();
+    const sangoma = makeUnit('sangoma-1', z05, 4, 4);
+    const allyA = makeUnit('ally-a', z04, 1, 3);
+    const allyB = makeUnit('ally-b', z04, 1, 3);
+    state = {
+      ...state,
+      players: {
+        ...state.players,
+        p1: { ...state.players.p1, battlefield: [sangoma, allyA, allyB] },
+      },
+    };
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+    state = applyAction(state, { type: 'END_TURN', playerId: 'p1' });
+
+    const a = state.players.p1.battlefield.find(x => x.instanceId === 'ally-a');
+    const b = state.players.p1.battlefield.find(x => x.instanceId === 'ally-b');
+    expect(a && b).toBeTruthy();
+    const healedA = a!.currentHealth > 1;
+    const healedB = b!.currentHealth > 1;
+    expect(healedA !== healedB).toBe(true);
+    expect(healedA || healedB).toBe(true);
+  });
+
+  it('heal is capped at maxHp', () => {
+    let state = startedGame();
+    const bigHealCard: Card = {
+      ...z01,
+      id: 'TEST-HEAL-CAP',
+      effects: [
+        {
+          trigger: 'on_turn_end',
+          description: 'test',
+          resolve: { kind: 'heal', amount: 50, target: { scope: 'random_ally' } },
+        },
+      ],
+    };
+    const healer = makeUnit('healer-cap', bigHealCard, 5, 5);
+    const target = makeUnit('target-cap', z01, 2, 5);
+    state = {
+      ...state,
+      players: {
+        ...state.players,
+        p1: { ...state.players.p1, battlefield: [healer, target] },
+      },
+    };
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    state = applyAction(state, { type: 'END_TURN', playerId: 'p1' });
+    const t = state.players.p1.battlefield.find(x => x.instanceId === 'target-cap');
+    expect(t?.currentHealth).toBe(5);
+  });
+
+  it('heal amount <= 0 is no-op', () => {
+    let state = startedGame();
+    const noopHealCard: Card = {
+      ...z01,
+      id: 'TEST-HEAL-ZERO',
+      effects: [
+        {
+          trigger: 'on_turn_end',
+          description: 'test',
+          resolve: { kind: 'heal', amount: 0, target: { scope: 'random_ally' } },
+        },
+      ],
+    };
+    const unitA = makeUnit('u-a', noopHealCard, 5, 5);
+    const unitB = makeUnit('u-b', z01, 1, 3);
+    state = {
+      ...state,
+      players: {
+        ...state.players,
+        p1: { ...state.players.p1, battlefield: [unitA, unitB] },
+      },
+    };
+    state = applyAction(state, { type: 'END_TURN', playerId: 'p1' });
+    expect(state.players.p1.battlefield.find(x => x.instanceId === 'u-b')?.currentHealth).toBe(1);
+  });
+
+  it('heal amount negative is no-op', () => {
+    let state = startedGame();
+    const negHealCard: Card = {
+      ...z01,
+      id: 'TEST-HEAL-NEG',
+      effects: [
+        {
+          trigger: 'on_turn_end',
+          description: 'test',
+          resolve: { kind: 'heal', amount: -3, target: { scope: 'random_ally' } },
+        },
+      ],
+    };
+    const unitA = makeUnit('neg-a', negHealCard, 5, 5);
+    const unitB = makeUnit('neg-b', z04, 1, 3);
+    state = {
+      ...state,
+      players: {
+        ...state.players,
+        p1: { ...state.players.p1, battlefield: [unitA, unitB] },
+      },
+    };
+    state = applyAction(state, { type: 'END_TURN', playerId: 'p1' });
+    expect(state.players.p1.battlefield.find(x => x.instanceId === 'neg-b')?.currentHealth).toBe(1);
+  });
+
+  it('regression: heal self (hero) from battlecry still works', () => {
+    let state = startedGame();
+    const o09 = allCards.find(c => c.id === 'O09')!;
+    state = {
+      ...state,
+      phase: 'principal',
+      activePlayerId: 'p1',
+      players: {
+        ...state.players,
+        p1: {
+          ...state.players.p1,
+          energy: 10,
+          heroHealth: 20,
+          hand: [o09],
+          battlefield: [],
+        },
+      },
+    };
+    state = applyAction(state, { type: 'PLAY_UNIT', playerId: 'p1', cardId: 'O09', targetSlot: 0 });
+    expect(state.players.p1.heroHealth).toBe(25);
+  });
+
+  it('only zulu cards use on_turn_end heal with random_ally (smoke)', () => {
+    const offenders = allCards.filter(
+      c =>
+        c.faction === 'zulu' &&
+        c.effects.some(
+          e =>
+            e.trigger === 'on_turn_end' &&
+            e.resolve.kind === 'heal' &&
+            e.resolve.target.scope !== 'random_ally',
+        ),
+    );
+    expect(offenders.map(c => c.id)).toEqual([]);
+  });
+});

--- a/src/engine/reducers.ts
+++ b/src/engine/reducers.ts
@@ -390,18 +390,47 @@ function resolveEffect(
       return next;
     }
     case 'heal': {
-      const targetId = resolver.target.scope === 'self' ? playerId : opponentId;
-      const p = state.players[targetId];
-      return {
-        ...state,
-        players: {
-          ...state.players,
-          [targetId]: {
-            ...p,
-            heroHealth: Math.min(p.heroMaxHealth, p.heroHealth + resolver.amount),
+      if (resolver.amount <= 0) return state;
+
+      if (resolver.target.scope === 'self') {
+        const p = state.players[playerId];
+        return {
+          ...state,
+          players: {
+            ...state.players,
+            [playerId]: {
+              ...p,
+              heroHealth: Math.min(p.heroMaxHealth, p.heroHealth + resolver.amount),
+            },
           },
-        },
-      };
+        };
+      }
+
+      if (resolver.target.scope === 'random_ally') {
+        const p = state.players[playerId];
+        const candidates = p.battlefield.filter(u => u.currentHealth < u.maxHealth);
+        if (candidates.length === 0) return state;
+
+        const pick = candidates[Math.floor(Math.random() * candidates.length)];
+        const live = p.battlefield.find(u => u.instanceId === pick.instanceId);
+        if (!live || live.currentHealth <= 0) return state;
+
+        const newHealth = Math.min(live.maxHealth, live.currentHealth + resolver.amount);
+        return {
+          ...state,
+          players: {
+            ...state.players,
+            [playerId]: {
+              ...p,
+              battlefield: p.battlefield.map(u =>
+                u.instanceId === live.instanceId ? { ...u, currentHealth: newHealth } : u,
+              ),
+            },
+          },
+        };
+      }
+
+      return state;
     }
     case 'damage': {
       if (resolver.target.scope === 'all_enemies') {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -24,6 +24,7 @@ export type TargetSelector =
   | { scope: 'all_enemies' }
   | { scope: 'all_allies' }
   | { scope: 'random_enemy' }
+  | { scope: 'random_ally' }
   | { scope: 'choose_enemy' }
   | { scope: 'choose_ally' };
 


### PR DESCRIPTION
Closes #26

## Provenance
<!-- author:cursor -->
author:cursor

## Contexte
Dernier bloquant M2. Deux corrections dans la meme PR :
1. Sangoma Guerisseuse (Z05) : `random_enemy` remplace par `random_ally` dans `src/data/cards.json`.
2. `resolveEffect` : branche `heal` + `random_ally` pour soigner une unite alliee blessee au hasard (plafond maxHp), sans casser `heal` + `self` (hero).

## Modifications
- `src/engine/types.ts` : ajout `TargetSelector` `random_ally`
- `src/data/cards.json` : Z05 `on_turn_end` cible `random_ally`
- `src/engine/reducers.ts` : logique heal unites + garde `amount <= 0`, relecture unite vivante avant application
- `src/engine/__tests__/sangoma.test.ts` : tests Vitest (no-op full HP, deux blesses un seul soigne, cap maxHp, amount 0 / negatif, regression O09 battlecry heal hero, smoke Zulu)

## Verdict QA initial
<!-- verdict:start -->
qa-pending
<!-- verdict:end -->

## Cross-review checklist
- [ ] CI verte (lint + test + build + coverage gate)
- [ ] Dev Reviewer Claude : audit attendu
- [ ] QA Claude : verdict attendu
- [ ] QA Challenger Claude : second avis + test adversarial dans `src/engine/__tests__/adversarial/claude/26-*.test.ts`
