### PR TITLE
docs(pm): M4 — Voyage de Sankofa scope + Sprint 03 planning

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -116,6 +116,10 @@
   color: "0052cc"
   description: "20 cartes, animations, écran d'accueil"
 
+- name: "M4 — Voyage de Sankofa"
+  color: "0052cc"
+  description: "IA heuristique + mode run 3 combats. Test de rejouabilité."
+
 - name: "Transverse"
   color: "8b949e"
   description: "Tâche transverse aux milestones"

--- a/docs/PM_RAPPORT_2026-04-28.md
+++ b/docs/PM_RAPPORT_2026-04-28.md
@@ -1,0 +1,81 @@
+# Rapport PM — Cadrage M4 « Voyage de Sankofa »
+**Date :** 2026-04-28
+**Agent :** Claude Code (PM)
+
+---
+
+## 1. Synthèse du cadrage M4
+
+Le PO a arbitré la direction post-POC : **profondeur avant largeur** — IA adversaire + mode run-based 3 combats. M4 ne vise pas à ajouter du contenu mais à prouver que le POC est *rejouable*. Si M4 fonctionne (verdict PO : « j'ai envie d'en relancer une »), on enclenche M5 ou M6. Sinon, on suspend et on recadre.
+
+**Philosophie imposée :** IA heuristique simple qui joue *correctement* (pas minmax). Une run de 3 combats (pas un roguelike). Minimum viable pour la question.
+
+---
+
+## 2. Livrables créés
+
+### Documents
+| Fichier | Contenu |
+|---|---|
+| `docs/POC_BRIEF.md` §M4 | Addendum fonctionnel : IA, run, lore, hors-périmètre, critère d'acceptation subjectif |
+| `docs/QUESTIONS.md` | Q-006 à Q-009 avec défauts proposés |
+| `docs/SPRINT_03.md` | Capacité, tickets, DoD, métrique de succès |
+| `.github/labels.yml` | Label `M4 — Voyage de Sankofa` |
+
+### GitHub
+| Artefact | URL |
+|---|---|
+| Milestone M4 | https://github.com/yans40/sankofa-poc/milestone/4 |
+| PR planning | https://github.com/yans40/sankofa-poc/pull/45 |
+
+---
+
+## 3. Issues créées (Sprint 03)
+
+| # | Titre | Auteur prévu | Size | Bloqué par |
+|---|---|---|---|---|
+| [#39](https://github.com/yans40/sankofa-poc/issues/39) | `[engine] IA adversaire heuristique value-of-board` | Claude | M | — démarrage immédiat |
+| [#40](https://github.com/yans40/sankofa-poc/issues/40) | `[engine] State machine mode run (3 combats, HP persistant)` | Claude | M | — démarrage immédiat (défauts Q-006/Q-007/Q-008 appliqués) |
+| [#41](https://github.com/yans40/sankofa-poc/issues/41) | `[ux] Écran sélection de carte entre combats` | Cursor | S | Dépend #40 |
+| [#42](https://github.com/yans40/sankofa-poc/issues/42) | `[ux] Écran carte du voyage + victoire/défaite run` | Cursor | M | Dépend #40 + idéalement Q-009 arbitrée |
+| [#43](https://github.com/yans40/sankofa-poc/issues/43) | `[ux] Lore : proverbes Sankofa avant chaque combat` | libre | S | — démarrage immédiat |
+| [#44](https://github.com/yans40/sankofa-poc/issues/44) | `[docs] Addendum M4 + Sprint 03 planning` | Claude | S | — cette PR |
+
+---
+
+## 4. Questions ouvertes Q-006 à Q-009
+
+| Q | Question | Défaut appliqué | Impact si non tranché |
+|---|---|---|---|
+| Q-006 | Soin partiel entre combats : +10 fixe ou % PV max ? | +10 fixe | Faible — défaut acceptable |
+| Q-007 | Doublons dans les propositions de cartes ? | Doublons autorisés | Faible — défaut acceptable |
+| Q-008 | Difficulté croissante : decks ou IA ? | Decks adverses prédéfinis | Moyen — bloque la création des 3 decks adverses |
+| Q-009 | Écran défaite : stats ou retour direct ? | Écran stats + bouton Rejouer | Moyen — bloque ticket #42 |
+
+**Recommandation** : trancher Q-008 et Q-009 en priorité pour débloquer les tickets Cursor.
+
+---
+
+## 5. Sprint 03 — État au lancement
+
+**Tickets démarrables immédiatement (sans arbitrage PO) :**
+- #39 — Claude (engine IA)
+- #40 — Claude (engine run state, défauts Q-006/Q-007/Q-008 appliqués)
+- #43 — libre (lore)
+- #41 — Cursor (après merge #40)
+
+**Tickets en attente PO :**
+- #42 — attend idéalement Q-009 (défaut applicable mais UX moins claire)
+
+---
+
+## 6. Recommandations
+
+1. **Arbitrer Q-008 et Q-009 dès que possible** pour libérer Cursor sur #42.
+2. **Démarrer #39 en priorité** (IA engine) — c'est le coeur de M4, sans dépendance.
+3. **Ne pas démarrer M5 ou M6** avant le verdict PO post-run M4.
+4. Si le test à 70% de victoires IA vs random s'avère difficile à calibrer, le seuil est documenté dans le ticket #39 — le dev (Claude) peut proposer un ajustement avant de fermer.
+
+---
+
+*Rapport généré par l'agent PM Claude — 2026-04-28.*

--- a/docs/POC_BRIEF.md
+++ b/docs/POC_BRIEF.md
@@ -635,6 +635,50 @@ Une carte est considérée comme implémentée si :
 
 ---
 
+## M4 — Voyage de Sankofa (addendum post-POC)
+
+> **Statut :** Cadré par le PM — en attente d'arbitrage PO sur Q-006 à Q-009.
+> **Objectif :** Prouver que le POC est rejouable. IA adversaire + mode run-based 3 combats.
+> **Philosophie :** Profondeur avant largeur. Pas de nouvelle faction, pas de PvP. Le minimum viable pour répondre à la question : *« j'ai envie d'en relancer une ? »*
+
+### M4.1 — IA adversaire heuristique
+
+- À chaque tour, l'IA évalue chaque coup possible par un score simple = **(dégâts potentiels infligés) + (valeur statline des unités jouées) − (mana inutilisé si non optimal)**. Joue le coup au meilleur score, recalcule, s'arrête quand aucun coup n'a un score > 0.
+- Pas de prédiction sur les tours suivants. Pas de bluff. Pas d'apprentissage.
+- **Seuils de validation** : l'IA doit battre un joueur qui joue au hasard ≥ 70 % du temps ; doit perdre face à un joueur sensé ≥ 50 % du temps. Ces seuils sont la définition de « correct » — ne pas viser plus.
+- Implémentation attendue dans `src/engine/ai/heuristic.ts` (engine pur, sans React/DOM).
+
+### M4.2 — Mode Voyage (run-based)
+
+- **Une run = 3 combats successifs** contre 3 adversaires de difficulté croissante (decks IA prédéfinis, non générés).
+- **Deck de départ** : 20 cartes liées à la faction choisie au lancement.
+- **Entre chaque combat** : le joueur choisit 1 carte parmi 3 propositions aléatoires à ajouter à son deck (21, puis 22 cartes).
+- **PV héros** : conservés entre combats + soin partiel au début de chaque nouveau combat (montant : cf. Q-006).
+- **Fin de run** : victoire si les 3 combats sont gagnés ; défaite si PV héros = 0 lors d'un combat.
+- **Pas** de meta-progression entre runs, pas de récompense persistante.
+- Implémentation attendue dans `src/engine/run/runState.ts`.
+
+### M4.3 — Lore
+
+- Avant chaque combat, un proverbe ou fragment Sankofa s'affiche (3 proverbes hardcodés pour M4).
+- Le nom *Voyage de Sankofa* renvoie au sens du concept (retourner chercher ce qu'on a oublié).
+
+### M4.4 — Hors-périmètre M4
+
+- ❌ PvP en ligne (M6)
+- ❌ Nouvelle faction (M5)
+- ❌ Meta-progression / collection / packs
+- ❌ Matchmaking / backend / persistance entre sessions
+- ❌ Campagne narrative complète (M7)
+
+### M4.5 — Critère d'acceptation M4
+
+> Verdict subjectif du PO après une run complète : *« j'ai envie d'en relancer une »*. Si non, M5/M6 sont gelés et la stratégie est rouverte.
+
+Questions ouvertes : Q-006, Q-007, Q-008, Q-009 (voir `docs/QUESTIONS.md`).
+
+---
+
 **Fin du brief.**
 
 *Pour toute question pendant le développement, créer une issue GitHub taguée `question:` ou consulter directement le PO.*

--- a/docs/QUESTIONS.md
+++ b/docs/QUESTIONS.md
@@ -81,4 +81,66 @@ Chaque question suit ce gabarit :
 
 ---
 
-*Q-001, Q-002, Q-003 : tranchées et implémentées. Q-004 : différée (décision PO attendue avant déploiement). Q-005 : tranchée (repo privé).*
+---
+
+## Questions M4 — Voyage de Sankofa
+
+### Q-006 — Soin partiel entre combats : montant fixe ou pourcentage ?
+**Statut :** 🔴 OUVERTE
+**Posée par :** Claude Code (PM)
+**Date :** 2026-04-28
+**Contexte :** Entre deux combats d'une run, le héros récupère des PV. Quel montant ?
+**Options envisagées :**
+  1. +10 PV fixe (plafonné à `heroMaxHealth`) — simple, prévisible
+  2. +20 % des PV max arrondi — proportionnel mais moins lisible
+**Recommandation tech :** Option 1 (+10 fixe).
+**Décision PO :** (à remplir)
+**Impact :** Ne bloque pas le ticket engine ; défaut appliqué : +10 fixe.
+
+---
+
+### Q-007 — Carte ajoutée entre combats : doublons autorisés ?
+**Statut :** 🔴 OUVERTE
+**Posée par :** Claude Code (PM)
+**Date :** 2026-04-28
+**Contexte :** Les 3 propositions de cartes entre combats peuvent-elles inclure une carte déjà présente dans le deck ?
+**Options envisagées :**
+  1. Oui (pas de filtre) — simplicité maximale
+  2. Non (exclure les cartes déjà à 3 copies)
+  3. Non (exclure strictement tout doublon)
+**Recommandation tech :** Option 1 pour M4.
+**Décision PO :** (à remplir)
+**Impact :** Ne bloque pas ; défaut : Option 1.
+
+---
+
+### Q-008 — Difficulté croissante : deck ou score IA ?
+**Statut :** 🔴 OUVERTE
+**Posée par :** Claude Code (PM)
+**Date :** 2026-04-28
+**Contexte :** Comment rendre les 3 combats de difficulté croissante ?
+**Options envisagées :**
+  1. Decks adverses prédéfinis de plus en plus solides — IA identique
+  2. Score heuristique IA augmenté (multiplicateur) — même deck
+  3. Les deux
+**Recommandation tech :** Option 1 — ne pas tweaker l'heuristique à ce stade.
+**Décision PO :** (à remplir)
+**Impact :** Bloque la création des 3 decks adverses. Défaut : Option 1.
+
+---
+
+### Q-009 — Écran après défaite lors d'une run ?
+**Statut :** 🔴 OUVERTE
+**Posée par :** Claude Code (PM)
+**Date :** 2026-04-28
+**Contexte :** Quand le héros tombe à 0 PV avant la fin des 3 combats, que voit le joueur ?
+**Options envisagées :**
+  1. Retour direct à FactionSelect
+  2. Écran « Défaite » avec stats + bouton Rejouer
+**Recommandation tech :** Option 2 — favorise le replay.
+**Décision PO :** (à remplir)
+**Impact :** Bloque le ticket `[ux] Écran carte du voyage + victoire/défaite`. Défaut : Option 2.
+
+---
+
+*Q-001 à Q-003 : tranchées. Q-004 : différée. Q-005 : tranchée. Q-006 à Q-009 : ouvertes M4 — défauts proposés consignés ci-dessus, démarrage engine possible sans arbitrage PO.*

--- a/docs/SPRINT_03.md
+++ b/docs/SPRINT_03.md
@@ -1,0 +1,78 @@
+# Sprint 03 — Voyage de Sankofa (du 2026-04-28 au 2026-05-12)
+
+> **Objectif :** Prouver que le POC est rejouable — IA correcte + run de 3 combats avec deck évolutif.
+
+---
+
+## Capacité
+
+| Agent | Tickets prévus | Type |
+|---|---|---|
+| Claude (Dev) | 2 tickets engine + 1 ticket docs | Engine pur TS + PM |
+| Cursor (Dev) | 2–3 tickets UI | React + UX |
+
+---
+
+## Tickets
+
+| # | Titre | Auteur prévu | Size | Statut |
+|---|---|---|---|---|
+| TBD | `[engine] IA adversaire heuristique value-of-board` | claude | M | open |
+| TBD | `[engine] State machine mode run (3 combats, HP persistant)` | claude | M | open |
+| TBD | `[ux] Écran sélection de carte entre combats (3 propositions)` | cursor | S | open |
+| TBD | `[ux] Écran carte du voyage + écrans victoire/défaite run` | cursor | M | open — dépend Q-009 (défaut: Option 2) |
+| TBD | `[ux] Lore : proverbes Sankofa avant chaque combat` | libre | S | open |
+| TBD | `[docs] Addendum M4 dans POC_BRIEF + mise à jour CLAUDE.md` | claude | S | open (cette PR) |
+
+> Les numéros d'issues seront mis à jour après création sur GitHub.
+
+---
+
+## Non-objectifs du sprint
+
+- Pas de PvP (M6)
+- Pas de nouvelle faction (M5)
+- Pas de meta-progression, collection, packs
+- Pas de matchmaking / backend / persistance entre sessions
+
+---
+
+## Questions PO ouvertes (Q-006 à Q-009)
+
+| Question | Impact | Défaut appliqué si non tranché |
+|---|---|---|
+| Q-006 — Soin partiel entre combats | Faible (défaut ok) | +10 PV fixe |
+| Q-007 — Doublons dans les propositions | Faible (défaut ok) | Doublons autorisés |
+| Q-008 — Difficulté croissante : deck ou IA ? | Moyen — bloque la création des decks adverses | Decks prédéfinis par combat |
+| Q-009 — Écran défaite run | Moyen — bloque le ticket `[ux] écran victoire/défaite` | Écran stats + bouton Rejouer |
+
+Les tickets engine démarrent **sans attendre** l'arbitrage PO car leurs défauts sont acceptables.
+Le ticket `[ux] Écran carte du voyage + victoire/défaite` attend idéalement Q-009 avant d'être pris par Cursor.
+
+---
+
+## Définition of Done — Sprint 03
+
+- [ ] Ticket engine IA mergé sur `develop`, tests verts, coverage ≥ 70 %
+- [ ] Ticket engine run-state mergé sur `develop`, tests verts
+- [ ] Ticket ux sélection de carte mergé
+- [ ] Ticket ux écran voyage/victoire/défaite mergé
+- [ ] Ticket ux lore mergé
+- [ ] Une run complète est jouable end-to-end dans le navigateur
+- [ ] L'IA bat un joueur random ≥ 70 % (test automatisé dans `__tests__/ai.test.ts`)
+- [ ] Coverage statements ≥ 70 % sur `develop`
+- [ ] Aucun verdict `qa-escalate` en suspens
+- [ ] PO peut jouer une run et donner le verdict de rejouabilité
+
+---
+
+## Métrique de succès du sprint
+
+> Verdict subjectif du PO après une run complète : **« j'ai envie d'en relancer une »**.
+>
+> Si non → M5/M6 gelés, stratégie rouverte avec le PO.
+> Si oui → M5 (largeur panthéon) ou M6 (PvP) selon priorité PO.
+
+---
+
+*Document généré par l'agent PM Claude — 2026-04-28.*

--- a/docs/SPRINT_03.md
+++ b/docs/SPRINT_03.md
@@ -17,14 +17,12 @@
 
 | # | Titre | Auteur prévu | Size | Statut |
 |---|---|---|---|---|
-| TBD | `[engine] IA adversaire heuristique value-of-board` | claude | M | open |
-| TBD | `[engine] State machine mode run (3 combats, HP persistant)` | claude | M | open |
-| TBD | `[ux] Écran sélection de carte entre combats (3 propositions)` | cursor | S | open |
-| TBD | `[ux] Écran carte du voyage + écrans victoire/défaite run` | cursor | M | open — dépend Q-009 (défaut: Option 2) |
-| TBD | `[ux] Lore : proverbes Sankofa avant chaque combat` | libre | S | open |
-| TBD | `[docs] Addendum M4 dans POC_BRIEF + mise à jour CLAUDE.md` | claude | S | open (cette PR) |
-
-> Les numéros d'issues seront mis à jour après création sur GitHub.
+| #39 | `[engine] IA adversaire heuristique value-of-board` | claude | M | open |
+| #40 | `[engine] State machine mode run (3 combats, HP persistant)` | claude | M | open |
+| #41 | `[ux] Écran sélection de carte entre combats (3 propositions)` | cursor | S | open |
+| #42 | `[ux] Écran carte du voyage + écrans victoire/défaite run` | cursor | M | open — dépend Q-009 (défaut: Option 2) |
+| #43 | `[ux] Lore : proverbes Sankofa avant chaque combat` | libre | S | open |
+| #44 | `[docs] Addendum M4 + Sprint 03 planning` | claude | S | open (cette PR) |
 
 ---
 

--- a/docs/qa-history.md
+++ b/docs/qa-history.md
@@ -13,3 +13,4 @@
 | 2026-04-27T23:12:10.164Z | #36 | challenger | qa-confirmed |
 | 2026-04-27T23:18:48.649Z | #37 | challenger | qa-confirmed |
 | 2026-04-28T07:29:39.933Z | #45 | claude | qa-passed |
+| 2026-04-28T07:30:38.793Z | #45 | challenger | qa-confirmed |

--- a/docs/qa-history.md
+++ b/docs/qa-history.md
@@ -12,3 +12,4 @@
 | 2026-04-27T20:00:40.016Z | #35 | challenger | qa-confirmed |
 | 2026-04-27T23:12:10.164Z | #36 | challenger | qa-confirmed |
 | 2026-04-27T23:18:48.649Z | #37 | challenger | qa-confirmed |
+| 2026-04-28T07:29:39.933Z | #45 | claude | qa-passed |


### PR DESCRIPTION
<!-- author:claude -->
author:claude

## Contexte
Cadrage M4 décidé par le PO après clôture du POC (M1+M2+M3). Test de rejouabilité avant enclencher M5/M6.

## Livrables
- Addendum M4 dans docs/POC_BRIEF.md (§M4 — IA heuristique, mode run 3 combats, lore)
- Q-006 à Q-009 dans docs/QUESTIONS.md avec défauts proposés
- docs/SPRINT_03.md : capacité, tickets, DoD, métrique de succès subjective
- Label "M4 — Voyage de Sankofa" dans .github/labels.yml

## Issues créées
- #39 [engine] IA adversaire heuristique value-of-board — size:M — Claude
- #40 [engine] State machine mode run (3 combats, HP persistant) — size:M — Claude
- #41 [ux] Écran sélection de carte entre combats — size:S — Cursor
- #42 [ux] Écran carte du voyage + victoire/défaite run — size:M — Cursor
- #43 [ux] Lore : proverbes Sankofa avant chaque combat — size:S — libre
- #44 [docs] Addendum M4 + Sprint 03 planning — size:S — Claude (cette PR)

## Questions PO ouvertes
- Q-006 : soin partiel entre combats (+10 fixe par défaut)
- Q-007 : doublons dans propositions (autorisés par défaut)
- Q-008 : difficulté croissante — decks ou IA ? (decks par défaut)
- Q-009 : écran défaite run (stats + bouton rejouer par défaut)

Tickets engine (#39, #40) peuvent démarrer sans arbitrage PO.
Ticket #42 attend idéalement Q-009.

## Verdict QA initial
<!-- verdict:start -->
qa-passed
<!-- verdict:end -->
Doc-only, no code, low risk.

## Cross-review checklist
- [ ] CI verte
- [ ] Dev Reviewer Cursor : audit léger (cohérence brief / labels / sprint)
- [ ] QA Cursor : verdict trivial (docs)