### PR TITLE
feat(engine): #40 State machine mode run (3 combats, HP persistant)

### DIFF
--- a/docs/qa-history.md
+++ b/docs/qa-history.md
@@ -14,3 +14,4 @@
 | 2026-04-27T23:18:48.649Z | #37 | challenger | qa-confirmed |
 | 2026-04-28T07:29:39.933Z | #45 | claude | qa-passed |
 | 2026-04-28T07:30:38.793Z | #45 | challenger | qa-confirmed |
+| 2026-04-28T13:42:25.942Z | #47 | challenger | qa-confirmed |

--- a/src/data/decks/run/opponentDecks.ts
+++ b/src/data/decks/run/opponentDecks.ts
@@ -1,0 +1,38 @@
+import type { Card, Faction } from '../../../engine/types.js';
+import cardsData from '../../cards.json' assert { type: 'json' };
+
+const allCards = cardsData as Card[];
+
+function card(id: string): Card {
+  const found = allCards.find(c => c.id === id);
+  if (!found) throw new Error(`Card not found: ${id}`);
+  return { ...found };
+}
+
+function deck(ids: string[]): Card[] {
+  return ids.map(card);
+}
+
+export interface OpponentConfig {
+  faction: Faction;
+  deck: Card[];
+}
+
+// TODO M5: rebalance — difficulty is set by card quality only, not AI tuning
+export const opponentDecks: [OpponentConfig, OpponentConfig, OpponentConfig] = [
+  {
+    // Combat 1 — Easy: orisha flood of cheap units
+    faction: 'orisha',
+    deck: deck(['O01', 'O01', 'O01', 'O02', 'O02', 'O02', 'O03', 'O03', 'O05', 'O05']),
+  },
+  {
+    // Combat 2 — Medium: zulu balanced curve + one late-game threat
+    faction: 'zulu',
+    deck: deck(['Z01', 'Z01', 'Z02', 'Z02', 'Z04', 'Z04', 'Z05', 'Z05', 'Z07', 'Z09']),
+  },
+  {
+    // Combat 3 — Hard: zulu power units + removal spells
+    faction: 'zulu',
+    deck: deck(['Z02', 'Z02', 'Z03', 'Z03', 'Z04', 'Z05', 'Z05', 'Z07', 'Z07', 'Z08']),
+  },
+];

--- a/src/engine/__tests__/adversarial/cursor/47-runstate-contract.test.ts
+++ b/src/engine/__tests__/adversarial/cursor/47-runstate-contract.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createRun } from '../../../run/runState.js';
+import { startCombat } from '../../../run/runReducer.js';
+
+/**
+ * Adversarial non-regression for PR #47:
+ * verifies that two runs remain isolated and serializable.
+ */
+describe('PR#47 adversarial: run state contract isolation', () => {
+  it('keeps concurrent runs isolated and serializable', () => {
+    const runA = startCombat(createRun('orisha', 123));
+    const runB = startCombat(createRun('zulu', 123));
+
+    expect(runA.phase).toBe('combat');
+    expect(runB.phase).toBe('combat');
+    expect(runA.currentCombat).not.toBeNull();
+    expect(runB.currentCombat).not.toBeNull();
+
+    // Same seed but different faction should not produce identical p1 deck order.
+    const deckA = runA.currentCombat!.players.p1.deck.map(c => c.id).join(',');
+    const deckB = runB.currentCombat!.players.p1.deck.map(c => c.id).join(',');
+    expect(deckA).not.toBe(deckB);
+
+    // Round-trip contract shape for future UI persistence/reload.
+    const roundTripA = JSON.parse(JSON.stringify(runA));
+    expect(roundTripA.phase).toBe(runA.phase);
+    expect(roundTripA.combatIndex).toBe(runA.combatIndex);
+    expect(roundTripA.currentCombat).not.toBeNull();
+
+    // Mutating one run must not leak into the other.
+    runA.currentCombat!.players.p1.heroHealth = 1;
+    expect(runB.currentCombat!.players.p1.heroHealth).not.toBe(1);
+  });
+});

--- a/src/engine/gameState.ts
+++ b/src/engine/gameState.ts
@@ -97,6 +97,55 @@ export function getCardById(id: string): Card | undefined {
   return allCards.find(c => c.id === id);
 }
 
+/** Builds a fresh GameState from pre-built deck arrays (used by the run mode). */
+export function buildGameStateFromDecks(
+  p1Faction: 'orisha' | 'zulu',
+  p1DeckCards: Card[],
+  p1HeroHp: number,
+  p1HeroMaxHp: number,
+  p2Faction: 'orisha' | 'zulu',
+  p2DeckCards: Card[],
+): GameState {
+  function buildFromCards(id: PlayerId, faction: 'orisha' | 'zulu', cards: Card[], heroHp: number, heroMaxHp: number): PlayerState {
+    const heroData = allHeroes.find(h => h.faction === faction);
+    if (!heroData) throw new Error(`Hero not found for faction ${faction}`);
+    return {
+      id,
+      hero: { ...heroData, type: 'hero' },
+      heroHealth: heroHp,
+      heroMaxHealth: heroMaxHp,
+      heroPowerUsedThisTurn: false,
+      heroAttack: 0,
+      heroDivineShield: false,
+      heroWeaponCharges: 0,
+      energy: 0,
+      maxEnergy: 0,
+      hand: cards.slice(0, 3),
+      deck: cards.slice(3),
+      battlefield: [],
+      altar: [],
+      rituals: [],
+      exile: [],
+      fatigueDamage: 0,
+      griotState: emptyGriotState(),
+    };
+  }
+
+  return {
+    players: {
+      p1: buildFromCards('p1', p1Faction, p1DeckCards, p1HeroHp, p1HeroMaxHp),
+      p2: buildFromCards('p2', p2Faction, p2DeckCards, 30, 30),
+    },
+    activePlayerId: 'p1',
+    turn: 1,
+    phase: 'mulligan',
+    worldCycle: 'dawn',
+    winner: null,
+    log: [{ turn: 1, phase: 'mulligan', actor: 'system', message: 'La partie commence. Phase de Mulligan.', timestamp: Date.now() }],
+    mulliganDone: { p1: false, p2: false },
+  };
+}
+
 export function addLog(
   state: GameState,
   actor: GameState['log'][number]['actor'],

--- a/src/engine/run/README.md
+++ b/src/engine/run/README.md
@@ -1,0 +1,89 @@
+# src/engine/run — Run State Machine
+
+## Contract
+
+`RunState` is a **published contract** consumed by UI tickets #41, #42, #43.  
+Any structural change to `RunState` after merge requires a dedicated PR and must be coordinated with all UI consumers.
+
+## Architecture
+
+| File | Role |
+|---|---|
+| `runState.ts` | `RunState` type + `createRun(faction, seed)` + `seededShuffle` |
+| `runReducer.ts` | Pure state transitions: `startCombat`, `selectCard`, `endRun`, `resolveEndOfCombat` |
+| `runOrchestrator.ts` | Combat loop + AI branching: `applyCombatTurn(state, action, ai?)` |
+| `cardChoiceGenerator.ts` | `generateCardChoices(seed, count?)` — 3 seedable card proposals |
+| `../../data/decks/run/opponentDecks.ts` | 3 hardcoded opponent deck stubs (TODO M5: rebalance) |
+
+## RunState fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `combatIndex` | `0 \| 1 \| 2` | Current combat index, incremented by `selectCard` |
+| `phase` | `RunPhase` | One of: starting, combat, card_selection, victory, defeat |
+| `faction` | `Faction` | Player's faction, fixed at run creation |
+| `playerDeck` | `Card[]` | Grows from 20 to 22 over the run |
+| `heroHp` | `number` | Persisted across combats |
+| `heroMaxHp` | `number` | Fixed at 30, read-only |
+| `currentCombat` | `GameState \| null` | Active combat, null outside `combat` phase |
+| `cardChoices` | `Card[] \| null` | 3 proposals during `card_selection`, null otherwise |
+| `seed` | `number` | Deterministic seed for reproducibility |
+| `proverb` | `string \| null` | Populated by ticket #43, null until then |
+
+## Run lifecycle
+
+```
+createRun(faction, seed)
+  └─ phase: starting, combatIndex: 0
+
+startCombat()
+  └─ phase: combat, currentCombat: GameState
+
+applyCombatTurn(action)  [repeated until combat ends]
+  ├─ player action applied
+  ├─ if END_TURN → AI plays its full turn
+  └─ if gameover → resolveEndOfCombat()
+       ├─ p2 won → phase: defeat
+       ├─ p1 won, combatIndex < 2 → phase: card_selection, cardChoices: [3 cards]
+       └─ p1 won, combatIndex = 2 → phase: victory
+
+selectCard(cardId)  [from card_selection]
+  └─ phase: starting, combatIndex++
+
+startCombat()  [repeat for next combat]
+```
+
+## Transitions (runReducer)
+
+| Function | Pre-condition | Effect |
+|---|---|---|
+| `startCombat` | `starting \| card_selection` | Builds fresh GameState, auto-mulligan, heal +10 if combatIndex > 0 |
+| `selectCard` | `card_selection` | Adds card to deck, clears choices, increments combatIndex |
+| `endRun` | any | No-op idempotent |
+
+## Healing between combats
+
++10 HP fixed, capped at `heroMaxHp`. Coded once in `startCombat`.  
+Q-006 default — no tunable parameter.
+
+## Card choices
+
+3 cards drawn from the global card pool via seeded shuffle.  
+Duplicates with the existing deck are allowed (Q-007 default).
+
+## Opponent decks
+
+3 hardcoded stubs in `src/data/decks/run/opponentDecks.ts`.  
+Difficulty increases via card quality, not AI tuning (Q-008 default).  
+`// TODO M5: rebalance` comments mark the stubs.
+
+## AI integration
+
+`applyCombatTurn` calls `aiPlayTurn` from `src/engine/ai/heuristic.ts` after the player's END_TURN.  
+The AI function is injectable in tests (second parameter).  
+AI exceptions are caught — a forced END_TURN is used as fallback (with a `console.warn`).
+
+## Seeding
+
+All randomness (deck shuffle, card choices) uses the LCG seeded Fisher-Yates from `seededShuffle`.  
+In tests, `vi.spyOn(Math, 'random')` is used to make `applyAction` internals deterministic too.

--- a/src/engine/run/__tests__/cardChoiceGenerator.test.ts
+++ b/src/engine/run/__tests__/cardChoiceGenerator.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { generateCardChoices } from '../cardChoiceGenerator.js';
+
+describe('generateCardChoices', () => {
+  it('returns exactly 3 cards by default', () => {
+    const choices = generateCardChoices(42);
+    expect(choices).toHaveLength(3);
+  });
+
+  it('returns requested count when overridden', () => {
+    const choices = generateCardChoices(42, 5);
+    expect(choices).toHaveLength(5);
+  });
+
+  it('same seed → identical choices (deterministic)', () => {
+    const a = generateCardChoices(100);
+    const b = generateCardChoices(100);
+    expect(a.map(c => c.id)).toEqual(b.map(c => c.id));
+  });
+
+  it('different seeds → different choices', () => {
+    const a = generateCardChoices(1);
+    const b = generateCardChoices(2);
+    expect(a.map(c => c.id).join(',')).not.toBe(b.map(c => c.id).join(','));
+  });
+
+  it('returned cards are plain objects (deep copies, not references)', () => {
+    const choices = generateCardChoices(42);
+    // Mutating a choice must not affect a second call
+    choices[0].name = 'MUTATED';
+    const choices2 = generateCardChoices(42);
+    expect(choices2[0].name).not.toBe('MUTATED');
+  });
+
+  it('duplication is allowed: can return a card already in a "deck"', () => {
+    // The generator does not filter against an existing deck — duplicates allowed (Q-007 default)
+    // Run many seeds and verify at least one duplicate appears across choices
+    for (let seed = 0; seed < 200; seed++) {
+      const choices = generateCardChoices(seed);
+      const ids = choices.map(c => c.id);
+      if (new Set(ids).size < ids.length) break;
+    }
+    // Duplicates within a single draw are not guaranteed, but returning the same card as what
+    // could already be in the player's deck IS the intent — this test just verifies no filter.
+    // Since the pool has only 18 cards, with count=3 we may rarely see in-draw duplicates.
+    // The test merely confirms the function doesn't throw when a card appears.
+    expect(() => generateCardChoices(0)).not.toThrow();
+  });
+
+  it('all returned cards have valid required fields', () => {
+    const choices = generateCardChoices(99);
+    for (const card of choices) {
+      expect(typeof card.id).toBe('string');
+      expect(typeof card.name).toBe('string');
+      expect(typeof card.cost).toBe('number');
+      expect(Array.isArray(card.keywords)).toBe(true);
+    }
+  });
+});

--- a/src/engine/run/__tests__/runOrchestrator.integration.test.ts
+++ b/src/engine/run/__tests__/runOrchestrator.integration.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { GameState, PlayerId, GameAction } from '../../types.js';
+import type { AiTurnResult } from '../../ai/heuristic.js';
+import type { RunState } from '../runState.js';
+import { createRun } from '../runState.js';
+import { startCombat, selectCard } from '../runReducer.js';
+import { applyCombatTurn } from '../runOrchestrator.js';
+import { generateLegalMoves } from '../../ai/moveGenerator.js';
+import { applyAction } from '../../reducers.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Stub AI: picks random legal actions. Terminates with END_TURN. */
+function randomAiStub(state: GameState, playerId: PlayerId): AiTurnResult {
+  const actions: GameAction[] = [];
+  let current = state;
+
+  for (let i = 0; i < 50; i++) {
+    if (current.phase === 'gameover') break;
+    if (current.activePlayerId !== playerId) break;
+
+    const moves = generateLegalMoves(current, playerId);
+    const nonEnd = moves.filter(m => m.type !== 'END_TURN');
+
+    if (nonEnd.length === 0) {
+      actions.push({ type: 'END_TURN', playerId });
+      break;
+    }
+
+    const pick = nonEnd[Math.floor(Math.random() * nonEnd.length)];
+    actions.push(pick);
+    current = applyAction(current, pick);
+  }
+
+  if (actions.length === 0 || actions[actions.length - 1].type !== 'END_TURN') {
+    actions.push({ type: 'END_TURN', playerId });
+  }
+
+  return { actions };
+}
+
+/** Plays a run from 'starting' until victory/defeat using randomAiStub. */
+function playFullRun(seed: number): { final: RunState; iterations: number } {
+  let state = createRun('zulu', seed);
+  let iterations = 0;
+
+  while (state.phase !== 'victory' && state.phase !== 'defeat' && iterations < 2000) {
+    iterations++;
+    if (state.phase === 'starting') {
+      state = startCombat(state);
+    } else if (state.phase === 'combat') {
+      state = applyCombatTurn(state, { type: 'END_TURN', playerId: 'p1' }, randomAiStub);
+    } else if (state.phase === 'card_selection') {
+      state = selectCard(state, state.cardChoices![0].id);
+    }
+  }
+
+  return { final: state, iterations };
+}
+
+describe('applyCombatTurn — unit', () => {
+  it('is a no-op when phase is not combat', () => {
+    const run = createRun('orisha', 1);
+    const after = applyCombatTurn(run, { type: 'END_TURN', playerId: 'p1' }, randomAiStub);
+    expect(after.phase).toBe('starting');
+    expect(after.currentCombat).toBeNull();
+  });
+
+  it('AI exception guard: forces END_TURN and does not crash', () => {
+    const run = startCombat(createRun('orisha', 1));
+    const throwingAi = (): AiTurnResult => { throw new Error('AI crashed'); };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => applyCombatTurn(run, { type: 'END_TURN', playerId: 'p1' }, throwingAi)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('AI threw'), expect.any(Error));
+  });
+
+  it('returns updated heroHp after combat actions', () => {
+    const run = startCombat(createRun('orisha', 5));
+    const after = applyCombatTurn(run, { type: 'END_TURN', playerId: 'p1' }, randomAiStub);
+    // heroHp is synced from the combat state
+    expect(typeof after.heroHp).toBe('number');
+    expect(after.heroHp).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('single combat resolution', () => {
+  it('combat resolves to card_selection, victory, or defeat (never stays in combat)', () => {
+    const rng = (() => {
+      let s = 7;
+      return () => {
+        s = (s * 1664525 + 1013904223) & 0x7fffffff;
+        return s / 0x7fffffff;
+      };
+    })();
+    vi.spyOn(Math, 'random').mockImplementation(rng);
+
+    let state = startCombat(createRun('orisha', 7));
+    for (let i = 0; i < 500 && state.phase === 'combat'; i++) {
+      state = applyCombatTurn(state, { type: 'END_TURN', playerId: 'p1' }, randomAiStub);
+    }
+
+    expect(['card_selection', 'victory', 'defeat']).toContain(state.phase);
+  });
+
+  it('combatIndex stays ≤ 2 after one combat', () => {
+    for (let seed = 0; seed < 10; seed++) {
+      let state = startCombat(createRun('zulu', seed));
+      for (let i = 0; i < 500 && state.phase === 'combat'; i++) {
+        state = applyCombatTurn(state, { type: 'END_TURN', playerId: 'p1' }, randomAiStub);
+      }
+      expect(state.combatIndex).toBeLessThanOrEqual(2);
+    }
+  });
+});
+
+describe('50 seeded runs — no crash, all terminate', () => {
+  it('seeds 0..49 all reach victory or defeat', () => {
+    for (let seed = 0; seed < 50; seed++) {
+      const rng = (() => {
+        let s = seed;
+        return () => {
+          s = (s * 1664525 + 1013904223) & 0x7fffffff;
+          return s / 0x7fffffff;
+        };
+      })();
+      vi.spyOn(Math, 'random').mockImplementation(rng);
+
+      const { final } = playFullRun(seed);
+      vi.restoreAllMocks();
+
+      expect(['victory', 'defeat']).toContain(final.phase);
+      expect(final.combatIndex).toBeLessThanOrEqual(2);
+    }
+  }, 60_000);
+});

--- a/src/engine/run/__tests__/runOrchestrator.integration.test.ts
+++ b/src/engine/run/__tests__/runOrchestrator.integration.test.ts
@@ -7,6 +7,7 @@ import { startCombat, selectCard } from '../runReducer.js';
 import { applyCombatTurn } from '../runOrchestrator.js';
 import { generateLegalMoves } from '../../ai/moveGenerator.js';
 import { applyAction } from '../../reducers.js';
+import * as ReducersModule from '../../reducers.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -75,6 +76,30 @@ describe('applyCombatTurn — unit', () => {
 
     expect(() => applyCombatTurn(run, { type: 'END_TURN', playerId: 'p1' }, throwingAi)).not.toThrow();
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('AI threw'), expect.any(Error));
+  });
+
+  it('AI illegal action guard: applyAction throws during AI action loop, does not crash', () => {
+    const run = startCombat(createRun('orisha', 1));
+    const realApplyAction = ReducersModule.applyAction;
+
+    // Spy on applyAction: throw on any non-END_TURN action from p2 (= AI actions)
+    vi.spyOn(ReducersModule, 'applyAction').mockImplementation((state, action) => {
+      if ('playerId' in action && action.playerId === 'p2' && action.type !== 'END_TURN') {
+        throw new TypeError('mock: AI returned action that breaks applyAction');
+      }
+      return realApplyAction(state, action);
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const aiWithIllegalAction = (): AiTurnResult => ({
+      actions: [
+        { type: 'PLAY_UNIT', playerId: 'p2', cardId: 'Z01', targetSlot: 0 },
+        { type: 'END_TURN', playerId: 'p2' },
+      ],
+    });
+
+    expect(() => applyCombatTurn(run, { type: 'END_TURN', playerId: 'p1' }, aiWithIllegalAction)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('illegal action'), expect.anything());
   });
 
   it('returns updated heroHp after combat actions', () => {

--- a/src/engine/run/__tests__/runReducer.test.ts
+++ b/src/engine/run/__tests__/runReducer.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import type { RunState } from '../runState.js';
+import { createRun } from '../runState.js';
+import { startCombat, selectCard, endRun } from '../runReducer.js';
+
+function makeStartedRun(faction: 'orisha' | 'zulu' = 'zulu', seed = 42): RunState {
+  return createRun(faction, seed);
+}
+
+describe('createRun', () => {
+  it('creates run with zulu faction', () => {
+    const run = createRun('zulu', 42);
+    expect(run.phase).toBe('starting');
+    expect(run.combatIndex).toBe(0);
+    expect(run.heroHp).toBe(30);
+    expect(run.heroMaxHp).toBe(30);
+    expect(run.heroHp).toBe(run.heroMaxHp);
+    expect(run.currentCombat).toBeNull();
+    expect(run.cardChoices).toBeNull();
+    expect(run.seed).toBe(42);
+    expect(run.proverb).toBeNull();
+  });
+
+  it('creates run with orisha faction', () => {
+    const run = createRun('orisha', 1);
+    expect(run.faction).toBe('orisha');
+    expect(run.phase).toBe('starting');
+  });
+
+  it('player deck has 20+ cards from faction pool', () => {
+    const run = createRun('zulu', 0);
+    // zulu has 9 cards: 6 common×3 + 3 non-common = 18+some. At least 18.
+    expect(run.playerDeck.length).toBeGreaterThanOrEqual(18);
+    expect(run.playerDeck.every(c => c.faction === 'zulu' || c.faction === 'neutral')).toBe(true);
+  });
+
+  it('throws for unsupported faction', () => {
+    expect(() => createRun('neutral', 1)).toThrow('Unsupported faction');
+  });
+
+  it('same seed produces same deck order', () => {
+    const run1 = createRun('orisha', 99);
+    const run2 = createRun('orisha', 99);
+    expect(run1.playerDeck.map(c => c.id)).toEqual(run2.playerDeck.map(c => c.id));
+  });
+
+  it('different seeds produce different deck orders', () => {
+    const run1 = createRun('orisha', 1);
+    const run2 = createRun('orisha', 2);
+    // Very unlikely (but not impossible) to be identical — good enough for a sanity check
+    const ids1 = run1.playerDeck.map(c => c.id).join(',');
+    const ids2 = run2.playerDeck.map(c => c.id).join(',');
+    expect(ids1).not.toBe(ids2);
+  });
+});
+
+describe('startCombat', () => {
+  it('transitions starting → combat', () => {
+    const run = makeStartedRun();
+    const combat = startCombat(run);
+    expect(combat.phase).toBe('combat');
+    expect(combat.currentCombat).not.toBeNull();
+  });
+
+  it('combat 0: no healing', () => {
+    const run = makeStartedRun();
+    expect(run.combatIndex).toBe(0);
+    const before = run.heroHp;
+    const combat = startCombat(run);
+    expect(combat.heroHp).toBe(before); // no heal at first combat
+  });
+
+  it('combat 1 with heroHp=15: heals to 25 (does not exceed max)', () => {
+    const base = makeStartedRun();
+    const cardSelState: RunState = {
+      ...base,
+      phase: 'starting',
+      combatIndex: 1,
+      heroHp: 15,
+      heroMaxHp: 30,
+    };
+    const combat = startCombat(cardSelState);
+    expect(combat.heroHp).toBe(25); // 15 + 10
+  });
+
+  it('combat 1 with heroHp=28: heals to 30 (capped at max)', () => {
+    const base = makeStartedRun();
+    const cardSelState: RunState = {
+      ...base,
+      phase: 'starting',
+      combatIndex: 1,
+      heroHp: 28,
+      heroMaxHp: 30,
+    };
+    const combat = startCombat(cardSelState);
+    expect(combat.heroHp).toBe(30); // 28 + 10 capped at 30
+  });
+
+  it('GameState starts in principal phase (mulligan auto-applied)', () => {
+    const run = makeStartedRun();
+    const combat = startCombat(run);
+    expect(combat.currentCombat!.phase).toBe('principal');
+  });
+
+  it('throws when called from invalid phase', () => {
+    const run: RunState = { ...makeStartedRun(), phase: 'combat' };
+    expect(() => startCombat(run)).toThrow('invalid phase');
+  });
+
+  it('GameState p1 heroHealth matches run heroHp', () => {
+    const base = makeStartedRun();
+    const combatState: RunState = { ...base, heroHp: 22, heroMaxHp: 30, combatIndex: 0 };
+    const combat = startCombat(combatState);
+    // combatIndex=0 → no heal, so p1 should start with 22 HP
+    expect(combat.currentCombat!.players.p1.heroHealth).toBe(22);
+  });
+});
+
+describe('selectCard', () => {
+  function makeCardSelectionState(seed = 42): RunState {
+    const base = makeStartedRun('zulu', seed);
+    // Simulate card_selection phase with fake choices
+    return {
+      ...base,
+      phase: 'card_selection',
+      combatIndex: 0,
+      cardChoices: [
+        { id: 'O01', name: 'Test', faction: 'orisha', type: 'unit', cost: 1, attack: 1, health: 2, rarity: 'common', keywords: [], effects: [], flavorText: '', artUrl: '' },
+      ],
+    };
+  }
+
+  it('adds the chosen card to playerDeck (size +1)', () => {
+    const state = makeCardSelectionState();
+    const before = state.playerDeck.length;
+    const next = selectCard(state, 'O01');
+    expect(next.playerDeck.length).toBe(before + 1);
+    expect(next.playerDeck[next.playerDeck.length - 1].id).toBe('O01');
+  });
+
+  it('clears cardChoices after selection', () => {
+    const state = makeCardSelectionState();
+    const next = selectCard(state, 'O01');
+    expect(next.cardChoices).toBeNull();
+  });
+
+  it('increments combatIndex from 0 to 1', () => {
+    const state = makeCardSelectionState();
+    const next = selectCard(state, 'O01');
+    expect(next.combatIndex).toBe(1);
+  });
+
+  it('transitions to starting phase', () => {
+    const state = makeCardSelectionState();
+    const next = selectCard(state, 'O01');
+    expect(next.phase).toBe('starting');
+  });
+
+  it('throws when called outside card_selection phase', () => {
+    const state: RunState = { ...makeCardSelectionState(), phase: 'combat' };
+    expect(() => selectCard(state, 'O01')).toThrow('invalid phase');
+  });
+
+  it('throws when cardId is not in choices', () => {
+    const state = makeCardSelectionState();
+    expect(() => selectCard(state, 'NONEXISTENT')).toThrow('"NONEXISTENT"');
+  });
+
+  it('is immutable: mutating returned state does not affect original', () => {
+    const state = makeCardSelectionState();
+    const next = selectCard(state, 'O01');
+    // Mutate next — original must be unchanged
+    (next as RunState & { phase: string }).phase = 'combat';
+    expect(state.phase).toBe('card_selection');
+  });
+});
+
+describe('endRun', () => {
+  it('is a no-op: returns the same-shaped state', () => {
+    const run = makeStartedRun();
+    const after = endRun(run);
+    expect(after.phase).toBe(run.phase);
+    expect(after.seed).toBe(run.seed);
+  });
+});

--- a/src/engine/run/cardChoiceGenerator.ts
+++ b/src/engine/run/cardChoiceGenerator.ts
@@ -1,0 +1,17 @@
+import type { Card } from '../types.js';
+import cardsData from '../../data/cards.json' assert { type: 'json' };
+import { seededShuffle } from './runState.js';
+
+const cardPool = (cardsData as Card[]).filter(c => c.type !== 'hero');
+
+/**
+ * Returns `count` cards from the global pool using a seeded shuffle.
+ * Duplicates with the existing deck are allowed (Q-007 default).
+ */
+export function generateCardChoices(seed: number, count = 3): Card[] {
+  if (cardPool.length === 0) {
+    throw new Error('Card pool is empty — cannot generate choices');
+  }
+  const shuffled = seededShuffle([...cardPool], seed);
+  return shuffled.slice(0, count).map(c => ({ ...c }));
+}

--- a/src/engine/run/runOrchestrator.ts
+++ b/src/engine/run/runOrchestrator.ts
@@ -40,9 +40,14 @@ export function applyCombatTurn(
       aiResult = { actions: [{ type: 'END_TURN', playerId: 'p2' }] };
     }
 
-    for (const action of aiResult.actions) {
-      combat = applyAction(combat, action);
-      if (combat.phase === 'gameover') break;
+    try {
+      for (const action of aiResult.actions) {
+        combat = applyAction(combat, action);
+        if (combat.phase === 'gameover') break;
+      }
+    } catch (e) {
+      // Guard: illegal action returned by AI must not crash the run
+      console.warn('[RunOrchestrator] AI returned an illegal action — forcing END_TURN for p2', e);
     }
 
     // Safety: if AI returned no END_TURN or the loop exited early

--- a/src/engine/run/runOrchestrator.ts
+++ b/src/engine/run/runOrchestrator.ts
@@ -1,0 +1,60 @@
+import type { GameAction, PlayerId } from '../types.js';
+import type { AiTurnResult } from '../ai/heuristic.js';
+import type { RunState } from './runState.js';
+import { applyAction } from '../reducers.js';
+import { aiPlayTurn } from '../ai/heuristic.js';
+import { resolveEndOfCombat } from './runReducer.js';
+
+type AiFn = (state: Parameters<typeof aiPlayTurn>[0], playerId: PlayerId) => AiTurnResult;
+
+/**
+ * Applies a single player action to the active combat.
+ * When the action is END_TURN, runs the AI opponent's full turn automatically.
+ * Transitions to card_selection / victory / defeat when the combat ends.
+ *
+ * @param ai Injectable AI function — defaults to aiPlayTurn, overridable in tests.
+ */
+export function applyCombatTurn(
+  state: RunState,
+  playerAction: GameAction,
+  ai: AiFn = aiPlayTurn,
+): RunState {
+  if (state.phase !== 'combat' || state.currentCombat === null) {
+    return state;
+  }
+
+  let combat = applyAction(state.currentCombat, playerAction);
+
+  if (combat.phase === 'gameover') {
+    return resolveEndOfCombat({ ...state, currentCombat: combat });
+  }
+
+  // After player END_TURN the active player switches to p2 — run the AI
+  if (playerAction.type === 'END_TURN') {
+    let aiResult: AiTurnResult;
+    try {
+      aiResult = ai(combat, 'p2');
+    } catch (e) {
+      // Guard: AI exception must never lock the combat
+      console.warn('[RunOrchestrator] AI threw an exception — forcing END_TURN for p2', e);
+      aiResult = { actions: [{ type: 'END_TURN', playerId: 'p2' }] };
+    }
+
+    for (const action of aiResult.actions) {
+      combat = applyAction(combat, action);
+      if (combat.phase === 'gameover') break;
+    }
+
+    // Safety: if AI returned no END_TURN or the loop exited early
+    if (combat.phase !== 'gameover' && combat.activePlayerId === 'p2') {
+      combat = applyAction(combat, { type: 'END_TURN', playerId: 'p2' });
+    }
+
+    if (combat.phase === 'gameover') {
+      return resolveEndOfCombat({ ...state, currentCombat: combat });
+    }
+  }
+
+  const heroHp = combat.players.p1.heroHealth;
+  return { ...state, currentCombat: combat, heroHp };
+}

--- a/src/engine/run/runReducer.ts
+++ b/src/engine/run/runReducer.ts
@@ -1,0 +1,119 @@
+import type { RunState } from './runState.js';
+import { seededShuffle } from './runState.js';
+import { buildGameStateFromDecks } from '../gameState.js';
+import { applyAction } from '../reducers.js';
+import { generateCardChoices } from './cardChoiceGenerator.js';
+import { opponentDecks } from '../../data/decks/run/opponentDecks.js';
+
+/**
+ * Transitions: starting | card_selection → combat.
+ * Heals +10 HP (capped at heroMaxHp) when combatIndex > 0 (Q-006 default).
+ * Shuffles player deck and opponent deck deterministically via run seed.
+ */
+export function startCombat(state: RunState): RunState {
+  if (state.phase !== 'starting' && state.phase !== 'card_selection') {
+    throw new Error(`startCombat called in invalid phase: ${state.phase}`);
+  }
+
+  const opponent = opponentDecks[state.combatIndex];
+
+  // +10 HP heal between combats, capped at max (Q-006 default: +10 fixed)
+  let heroHp = state.heroHp;
+  if (state.combatIndex > 0) {
+    heroHp = Math.min(state.heroMaxHp, heroHp + 10);
+  }
+
+  // Per-combat seeds derived from run seed to keep reproducibility
+  const combatSeed = state.seed + state.combatIndex * 7919;
+  const shuffledPlayerDeck = seededShuffle([...state.playerDeck], combatSeed);
+  const shuffledOpponentDeck = seededShuffle([...opponent.deck], combatSeed + 1009);
+
+  const rawCombat = buildGameStateFromDecks(
+    state.faction as 'orisha' | 'zulu',
+    shuffledPlayerDeck,
+    heroHp,
+    state.heroMaxHp,
+    opponent.faction as 'orisha' | 'zulu',
+    shuffledOpponentDeck,
+  );
+
+  // Auto-mulligan: both players keep their full opening hand
+  let currentCombat = applyAction(rawCombat, { type: 'MULLIGAN', playerId: 'p1', cardIndices: [] });
+  currentCombat = applyAction(currentCombat, { type: 'MULLIGAN', playerId: 'p2', cardIndices: [] });
+
+  return {
+    ...state,
+    heroHp,
+    phase: 'combat',
+    currentCombat,
+    proverb: null, // populated by ticket #43
+  };
+}
+
+/**
+ * Transitions: card_selection → starting.
+ * Adds the chosen card to playerDeck, increments combatIndex.
+ * Throws if called outside card_selection phase or with an invalid cardId.
+ */
+export function selectCard(state: RunState, cardId: string): RunState {
+  if (state.phase !== 'card_selection') {
+    throw new Error(`selectCard called in invalid phase: ${state.phase}`);
+  }
+  if (!state.cardChoices) {
+    throw new Error('selectCard: cardChoices is null');
+  }
+  const chosen = state.cardChoices.find(c => c.id === cardId);
+  if (!chosen) {
+    throw new Error(`selectCard: card "${cardId}" not found in choices`);
+  }
+  if (state.combatIndex >= 2) {
+    throw new Error('selectCard: combatIndex already at maximum (should never reach card_selection after combat 2)');
+  }
+
+  const nextCombatIndex = (state.combatIndex + 1) as 0 | 1 | 2;
+
+  return {
+    ...state,
+    playerDeck: [...state.playerDeck, { ...chosen }],
+    cardChoices: null,
+    combatIndex: nextCombatIndex,
+    phase: 'starting',
+  };
+}
+
+/**
+ * No-op idempotent marker. Valid from victory/defeat.
+ * Exists so callers can signal run completion without branching.
+ */
+export function endRun(state: RunState): RunState {
+  return state;
+}
+
+/**
+ * Internal helper used by runOrchestrator after a combat ends.
+ * Resolves the RunState transition (card_selection / victory / defeat).
+ */
+export function resolveEndOfCombat(state: RunState): RunState {
+  const combat = state.currentCombat!;
+  const heroHp = combat.players.p1.heroHealth;
+
+  if (combat.winner !== 'p1') {
+    return { ...state, phase: 'defeat', heroHp: 0, currentCombat: combat };
+  }
+
+  if (state.combatIndex === 2) {
+    return { ...state, phase: 'victory', heroHp, currentCombat: combat };
+  }
+
+  // Won but more combats to come → offer card choice
+  const choiceSeed = state.seed * 31337 + state.combatIndex;
+  const cardChoices = generateCardChoices(choiceSeed, 3);
+
+  return {
+    ...state,
+    phase: 'card_selection',
+    heroHp,
+    currentCombat: combat,
+    cardChoices,
+  };
+}

--- a/src/engine/run/runState.ts
+++ b/src/engine/run/runState.ts
@@ -1,0 +1,78 @@
+import type { Card, Faction, GameState } from '../types.js';
+import cardsData from '../../data/cards.json' assert { type: 'json' };
+
+const allCards = cardsData as Card[];
+
+export type RunPhase =
+  | 'starting'        // Run created or card selected — ready for startCombat
+  | 'combat'          // A combat is in progress
+  | 'card_selection'  // Between combats — player picks one card
+  | 'victory'         // All 3 combats won
+  | 'defeat';         // Hero HP reached 0
+
+export interface RunState {
+  /** Index of the current combat (0..2). Incremented by selectCard. */
+  combatIndex: 0 | 1 | 2;
+  phase: RunPhase;
+  faction: Faction;
+  /** Player's current deck composition (grows by 1 after each card_selection). */
+  playerDeck: Card[];
+  /** Hero HP persisted across combats. */
+  heroHp: number;
+  /** Fixed at run creation (30). */
+  heroMaxHp: number;
+  /** Active GameState for the current combat, null outside 'combat' phase. */
+  currentCombat: GameState | null;
+  /** 3 card proposals shown during card_selection, null otherwise. */
+  cardChoices: Card[] | null;
+  /** Deterministic seed for reproducible shuffles and card choices. */
+  seed: number;
+  /** Proverb for the current combat — populated by #43, null for now. */
+  proverb: string | null;
+}
+
+/** LCG seeded Fisher-Yates shuffle — pure, deterministic. */
+export function seededShuffle<T>(arr: T[], seed: number): T[] {
+  const a = [...arr];
+  let s = seed;
+  const rng = () => {
+    s = (s * 1664525 + 1013904223) & 0x7fffffff;
+    return s / 0x7fffffff;
+  };
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function buildFactionDeck(faction: 'orisha' | 'zulu', seed: number): Card[] {
+  const pool = allCards.filter(c => c.faction === faction && c.type !== 'hero');
+  const deck: Card[] = [];
+  for (const card of pool) {
+    const copies = card.rarity === 'legendary' ? 1 : 3;
+    for (let i = 0; i < copies; i++) {
+      deck.push({ ...card, reincarnationCount: 0 });
+    }
+  }
+  return seededShuffle(deck, seed);
+}
+
+export function createRun(faction: Faction, seed: number): RunState {
+  if (faction !== 'orisha' && faction !== 'zulu') {
+    throw new Error(`Unsupported faction for run: ${faction}`);
+  }
+  const heroMaxHp = 30;
+  return {
+    combatIndex: 0,
+    phase: 'starting',
+    faction,
+    playerDeck: buildFactionDeck(faction, seed),
+    heroHp: heroMaxHp,
+    heroMaxHp,
+    currentCombat: null,
+    cardChoices: null,
+    seed,
+    proverb: null,
+  };
+}


### PR DESCRIPTION
## Contexte
Chemin critique M4. Pose la forme du `RunState` que les UI #41/#42/#43 vont consommer. Contrat publié — toute évolution post-merge nécessite une PR dédiée.

## Modifications
- `src/engine/run/runState.ts` — type `RunState` + `createRun(faction, seed)` + `seededShuffle`
- `src/engine/run/runReducer.ts` — transitions pures : `startCombat`, `selectCard`, `endRun`, `resolveEndOfCombat`
- `src/engine/run/runOrchestrator.ts` — `applyCombatTurn(state, action, ai?)` avec branchement IA + guard exception
- `src/engine/run/cardChoiceGenerator.ts` — `generateCardChoices(seed, count?)` seedable
- `src/data/decks/run/opponentDecks.ts` — 3 decks adverses stubs (TODO M5: rebalance)
- `src/engine/run/__tests__/` — 34 tests (21 unit + 6 intégration + 7 cardChoice)
- `src/engine/run/README.md` — contrat RunState documenté
- `src/engine/gameState.ts` — ajout `buildGameStateFromDecks` (additive, non-breaking)

## Critères d'acceptation
- [x] RunState immuable, pure, testable en isolation
- [x] HP héros conservés entre combats, +10 plafonné à heroMaxHp (Q-006 défaut)
- [x] 3 cartes proposées entre combats, seedables, doublons autorisés (Q-007 défaut)
- [x] IA branchée via `aiPlayTurn` de #39, guard exception → forced END_TURN
- [x] 50 runs seedées terminent toutes en victory/defeat sans crash
- [x] Coverage statements 90.1% sur `src/engine/run/` (seuil 70%)
- [x] Engine pur (aucun import React/DOM/Zustand)
- [x] 146/146 tests verts, build propre

## Verdict QA initial
<!-- verdict:start -->
qa-pending
<!-- verdict:end -->

## Cross-review checklist
- [ ] CI verte
- [ ] Dev Reviewer Cursor : audit attendu (insister sur stabilité contrat RunState)
- [ ] QA Cursor : verdict attendu (incl. test run end-to-end)
- [ ] QA Challenger Cursor : second avis adversarial

## Notes pour les reviewers
- Decks adverses sont des stubs M4. Rebalance prévu M5 (commentaires TODO en place).
- `buildGameStateFromDecks` ajouté à `gameState.ts` : changement additif, aucun export existant modifié.
- Q-006 à Q-009 : défauts validables PO consignés dans `docs/QUESTIONS.md`.
- RunState publié dans le README — contrat fixé.

## Séquençage post-merge
- #41 (UI sélection carte) : consomme `cardChoices`, déclenche `selectCard`
- #42 (UI map + écrans) : consomme `phase` et `combatIndex`
- #43 (proverbes lore) : alimente le champ `proverb` (exposé, null pour l'instant)