### PR TITLE
feat(ux): #42 Écran carte du voyage + victoire/défaite + routing run

### DIFF
--- a/docs/qa-history.md
+++ b/docs/qa-history.md
@@ -16,3 +16,4 @@
 | 2026-04-28T07:30:38.793Z | #45 | challenger | qa-confirmed |
 | 2026-04-28T13:42:25.942Z | #47 | challenger | qa-confirmed |
 | 2026-04-28T19:04:39.055Z | #48 | challenger | qa-confirmed |
+| 2026-04-29T12:55:41.930Z | #49 | challenger | qa-confirmed |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,14 +4,19 @@ import { HotSeatScreen } from './screens/HotSeatScreen.js';
 import { VictoryScreen } from './screens/VictoryScreen.js';
 import { MulliganScreen } from './components/MulliganModal/MulliganModal.js';
 import { Board } from './components/Board/Board.js';
+import { RunRouter } from './ui/run/RunRouter.js';
 
 export default function App() {
   const screen = useGameStore(s => s.screen);
+  const run = useGameStore(s => s.run);
 
+  // Run mode takes over when a run is active
+  if (run !== null) return <RunRouter />;
+
+  // Hot-seat mode (M2)
   if (screen === 'faction_select') return <FactionSelect />;
   if (screen === 'mulligan')      return <MulliganScreen />;
   if (screen === 'hotseat')       return <HotSeatScreen />;
-  // TODO #42: route run phases (card_selection/victory/defeat) to dedicated run screens.
   if (screen === 'game')          return <Board />;
   if (screen === 'gameover')      return <VictoryScreen />;
 

--- a/src/engine/__tests__/adversarial/cursor/49-runstate-json-roundtrip.test.ts
+++ b/src/engine/__tests__/adversarial/cursor/49-runstate-json-roundtrip.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { createRun } from '../../../run/runState.js';
+import { startCombat } from '../../../run/runReducer.js';
+
+/**
+ * Adversarial non-regression for PR #49:
+ * QA initial validated the UI flow, this test locks the RunState JSON
+ * round-trip contract for future reload/persistence work.
+ */
+describe('PR#49 adversarial: RunState JSON round-trip', () => {
+  it('keeps critical fields stable after stringify/parse', () => {
+    const starting = createRun('zulu', 490042);
+    const combat = startCombat(starting);
+
+    const startRoundTrip = JSON.parse(JSON.stringify(starting));
+    const combatRoundTrip = JSON.parse(JSON.stringify(combat));
+
+    expect(startRoundTrip.phase).toBe('starting');
+    expect(startRoundTrip.combatIndex).toBe(0);
+    expect(startRoundTrip.currentCombat).toBeNull();
+    expect(startRoundTrip.playerDeck.length).toBe(starting.playerDeck.length);
+
+    expect(combatRoundTrip.phase).toBe('combat');
+    expect(combatRoundTrip.combatIndex).toBe(0);
+    expect(combatRoundTrip.currentCombat).not.toBeNull();
+    expect(combatRoundTrip.heroHp).toBe(combat.heroHp);
+    expect(combatRoundTrip.heroMaxHp).toBe(combat.heroMaxHp);
+    expect(combatRoundTrip.playerDeck.length).toBe(combat.playerDeck.length);
+    expect(combatRoundTrip.currentCombat.players.p1.heroHealth).toBe(
+      combat.currentCombat!.players.p1.heroHealth,
+    );
+  });
+});

--- a/src/screens/FactionSelect.tsx
+++ b/src/screens/FactionSelect.tsx
@@ -82,6 +82,7 @@ function FactionCard({
 
 export function FactionSelect() {
   const startGame = useGameStore(s => s.startGame);
+  const initRun = useGameStore(s => s.initRun);
   const [p1, setP1] = useState<Faction>('orisha');
   const [p2, setP2] = useState<Faction>('zulu');
 
@@ -135,13 +136,22 @@ export function FactionSelect() {
         </div>
       </div>
 
-      <button
-        type="button"
-        onClick={() => startGame(p1, p2)}
-        className="rounded-full bg-yellow-500 px-12 py-4 text-lg font-black text-black shadow-lg shadow-yellow-500/25 transition-transform duration-200 hover:scale-[1.02] hover:bg-yellow-400 active:scale-[0.98]"
-      >
-        Commencer la partie
-      </button>
+      <div className="flex flex-col sm:flex-row gap-4 items-center">
+        <button
+          type="button"
+          onClick={() => startGame(p1, p2)}
+          className="rounded-full bg-gray-700 px-10 py-3 text-base font-bold text-white shadow-lg transition-transform duration-200 hover:scale-[1.02] hover:bg-gray-600 active:scale-[0.98]"
+        >
+          Partie libre (hot-seat)
+        </button>
+        <button
+          type="button"
+          onClick={() => initRun(p1)}
+          className="rounded-full bg-yellow-500 px-12 py-4 text-lg font-black text-black shadow-lg shadow-yellow-500/25 transition-transform duration-200 hover:scale-[1.02] hover:bg-yellow-400 active:scale-[0.98]"
+        >
+          Commencer le voyage
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/screens/__tests__/FactionSelect.test.tsx
+++ b/src/screens/__tests__/FactionSelect.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FactionSelect } from '../FactionSelect.js';
+import * as storeModule from '../../store/gameStore.js';
+
+vi.mock('../../store/gameStore.js', () => ({
+  useGameStore: vi.fn(),
+}));
+
+const useGameStoreMock = storeModule.useGameStore as unknown as ReturnType<typeof vi.fn>;
+
+const startGame = vi.fn();
+const initRun = vi.fn();
+
+beforeEach(() => {
+  startGame.mockReset();
+  initRun.mockReset();
+  useGameStoreMock.mockImplementation((selector: (s: object) => unknown) =>
+    selector({ startGame, initRun }),
+  );
+});
+
+describe('FactionSelect — régression hot-seat M2', () => {
+  it('affiche les deux boutons de lancement', () => {
+    render(<FactionSelect />);
+    expect(screen.getByRole('button', { name: /partie libre/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /commencer le voyage/i })).toBeTruthy();
+  });
+
+  it('"Partie libre" appelle startGame et pas initRun', () => {
+    render(<FactionSelect />);
+    fireEvent.click(screen.getByRole('button', { name: /partie libre/i }));
+    expect(startGame).toHaveBeenCalledTimes(1);
+    expect(initRun).not.toHaveBeenCalled();
+  });
+
+  it('"Partie libre" passe les factions p1/p2 par défaut (orisha vs zulu)', () => {
+    render(<FactionSelect />);
+    fireEvent.click(screen.getByRole('button', { name: /partie libre/i }));
+    expect(startGame).toHaveBeenCalledWith('orisha', 'zulu');
+  });
+
+  it('"Commencer le voyage" appelle initRun et pas startGame', () => {
+    render(<FactionSelect />);
+    fireEvent.click(screen.getByRole('button', { name: /commencer le voyage/i }));
+    expect(initRun).toHaveBeenCalledTimes(1);
+    expect(startGame).not.toHaveBeenCalled();
+  });
+
+  it('"Commencer le voyage" utilise la faction p1 sélectionnée', () => {
+    render(<FactionSelect />);
+    // Two "Zoulou" cards exist (P1 + P2) — first one is P1
+    const zuluCards = screen.getAllByRole('button', { name: /zoulou/i });
+    fireEvent.click(zuluCards[0]);
+    fireEvent.click(screen.getByRole('button', { name: /commencer le voyage/i }));
+    expect(initRun).toHaveBeenCalledWith('zulu');
+  });
+});

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -24,6 +24,7 @@ interface GameStore {
   screen: 'faction_select' | 'mulligan' | 'hotseat' | 'game' | 'gameover';
   hotSeatPending: PlayerId | null;
   run: RunState | null;
+  runTotalDamageDealt: number;
 
   startGame: (p1: 'orisha' | 'zulu', p2: 'orisha' | 'zulu') => void;
   dispatch: (action: GameAction) => void;
@@ -43,6 +44,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   screen: 'faction_select',
   hotSeatPending: null,
   run: null,
+  runTotalDamageDealt: 0,
 
   startGame: (p1, p2) => {
     const state = initialGameState(p1, p2);
@@ -55,11 +57,15 @@ export const useGameStore = create<GameStore>((set, get) => ({
     // Run mode: route all combat actions through applyCombatTurn (handles AI + gameover)
     if (run?.phase === 'combat') {
       const syncedRun: RunState = { ...run, currentCombat: get().gameState };
+      const prevP2Hp = syncedRun.currentCombat!.players.p2.heroHealth;
       const updatedRun = applyCombatTurn(syncedRun, action, aiPlayTurn);
+      const nextP2Hp = updatedRun.currentCombat?.players.p2.heroHealth ?? 0;
+      const dmg = Math.max(0, prevP2Hp - nextP2Hp);
       set({
         run: updatedRun,
         gameState: updatedRun.currentCombat ?? get().gameState,
         selection: { kind: 'none' },
+        runTotalDamageDealt: get().runTotalDamageDealt + dmg,
       });
       return;
     }
@@ -99,7 +105,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   initRun: (faction) => {
     const seed = Math.floor(Math.random() * 1_000_000);
     const run = createRun(faction, seed);
-    set({ run });
+    set({ run, runTotalDamageDealt: 0 });
   },
 
   startRunCombat: () => {
@@ -109,5 +115,5 @@ export const useGameStore = create<GameStore>((set, get) => ({
     set({ run: nextRun, gameState: nextRun.currentCombat!, selection: { kind: 'none' } });
   },
 
-  resetRun: () => set({ run: null }),
+  resetRun: () => set({ run: null, runTotalDamageDealt: 0 }),
 }));

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -3,7 +3,10 @@ import type { GameState, GameAction, PlayerId } from '../engine/types.js';
 import { initialGameState } from '../engine/gameState.js';
 import { applyAction } from '../engine/reducers.js';
 import type { RunState } from '../engine/run/runState.js';
-import { selectCard } from '../engine/run/runReducer.js';
+import { createRun } from '../engine/run/runState.js';
+import { selectCard, startCombat } from '../engine/run/runReducer.js';
+import { applyCombatTurn } from '../engine/run/runOrchestrator.js';
+import { aiPlayTurn } from '../engine/ai/heuristic.js';
 
 export type SelectionMode =
   | { kind: 'none' }
@@ -27,6 +30,9 @@ interface GameStore {
   setSelection: (mode: SelectionMode) => void;
   confirmHotSeat: () => void;
   selectRunCard: (cardId: string) => void;
+  initRun: (faction: 'orisha' | 'zulu') => void;
+  startRunCombat: () => void;
+  resetRun: () => void;
 }
 
 export const useGameStore = create<GameStore>((set, get) => ({
@@ -44,14 +50,26 @@ export const useGameStore = create<GameStore>((set, get) => ({
   },
 
   dispatch: (action) => {
+    const run = get().run;
+
+    // Run mode: route all combat actions through applyCombatTurn (handles AI + gameover)
+    if (run?.phase === 'combat') {
+      const syncedRun: RunState = { ...run, currentCombat: get().gameState };
+      const updatedRun = applyCombatTurn(syncedRun, action, aiPlayTurn);
+      set({
+        run: updatedRun,
+        gameState: updatedRun.currentCombat ?? get().gameState,
+        selection: { kind: 'none' },
+      });
+      return;
+    }
+
+    // Hot-seat mode
     const prev = get().gameState;
     const next = applyAction(prev, action);
-    // Detect turn switch → show hot-seat screen
     const wasActive = prev.activePlayerId;
     const isActive = next.activePlayerId;
     const turnChanged = wasActive !== isActive && next.phase !== 'gameover' && next.phase !== 'mulligan';
-
-    // Detect mulligan completion → move to game
     const mulliganDone = prev.phase === 'mulligan' && next.phase !== 'mulligan';
 
     if (next.phase === 'gameover') {
@@ -77,4 +95,19 @@ export const useGameStore = create<GameStore>((set, get) => ({
     const nextRun = selectCard(run, cardId);
     set({ run: nextRun });
   },
+
+  initRun: (faction) => {
+    const seed = Math.floor(Math.random() * 1_000_000);
+    const run = createRun(faction, seed);
+    set({ run });
+  },
+
+  startRunCombat: () => {
+    const run = get().run;
+    if (!run || run.phase !== 'starting') return;
+    const nextRun = startCombat(run);
+    set({ run: nextRun, gameState: nextRun.currentCombat!, selection: { kind: 'none' } });
+  },
+
+  resetRun: () => set({ run: null }),
 }));

--- a/src/ui/run/DefeatScreen.tsx
+++ b/src/ui/run/DefeatScreen.tsx
@@ -1,0 +1,69 @@
+import { useGameStore } from '../../store/gameStore.js';
+
+const INITIAL_DECK_SIZE = 20;
+
+export function DefeatScreen() {
+  const run = useGameStore(s => s.run);
+  const resetRun = useGameStore(s => s.resetRun);
+  const initRun = useGameStore(s => s.initRun);
+
+  if (!run) return null;
+
+  const cardsAdded = run.playerDeck.length - INITIAL_DECK_SIZE;
+
+  function handleRetry() {
+    resetRun();
+    initRun(run!.faction as 'orisha' | 'zulu');
+  }
+
+  function handleHome() {
+    resetRun();
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-black flex flex-col items-center justify-center gap-8 px-4 py-12">
+      <div className="text-center space-y-4">
+        <div className="text-7xl">💀</div>
+        <h1 className="text-5xl font-black text-red-400">Le voyage s'arrête ici</h1>
+        <p className="text-gray-300 text-lg max-w-md mx-auto">
+          Le héros est tombé. Sankofa attend un autre porteur.
+        </p>
+      </div>
+
+      <div className="w-full max-w-sm rounded-2xl border border-red-900/40 bg-red-950/20 p-6 space-y-3">
+        <h2 className="text-center text-sm font-bold uppercase tracking-widest text-red-400/80 mb-4">
+          Récapitulatif
+        </h2>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-400">Défaite au combat</span>
+          <span className="font-bold text-red-400">{run.combatIndex + 1} / 3</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-400">Cartes ajoutées</span>
+          <span className="font-bold text-blue-300">{cardsAdded}</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-400">Taille du deck</span>
+          <span className="font-bold text-blue-300">{run.playerDeck.length}</span>
+        </div>
+      </div>
+
+      <div className="flex gap-4">
+        <button
+          type="button"
+          onClick={handleRetry}
+          className="rounded-full bg-red-600 px-10 py-3 text-base font-black text-white shadow-lg shadow-red-600/25 transition-transform duration-200 hover:scale-[1.02] hover:bg-red-500 active:scale-[0.98]"
+        >
+          Réessayer
+        </button>
+        <button
+          type="button"
+          onClick={handleHome}
+          className="rounded-full bg-gray-700 px-10 py-3 text-base font-bold text-white transition-transform duration-200 hover:scale-[1.02] hover:bg-gray-600 active:scale-[0.98]"
+        >
+          Retour à l'accueil
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/run/DefeatScreen.tsx
+++ b/src/ui/run/DefeatScreen.tsx
@@ -6,10 +6,12 @@ export function DefeatScreen() {
   const run = useGameStore(s => s.run);
   const resetRun = useGameStore(s => s.resetRun);
   const initRun = useGameStore(s => s.initRun);
+  const totalDamageDealt = useGameStore(s => s.runTotalDamageDealt) ?? 0;
 
   if (!run) return null;
 
   const cardsAdded = run.playerDeck.length - INITIAL_DECK_SIZE;
+  const hpLost = run.heroMaxHp - run.heroHp;
 
   function handleRetry() {
     resetRun();
@@ -37,6 +39,14 @@ export function DefeatScreen() {
         <div className="flex justify-between text-sm">
           <span className="text-gray-400">Défaite au combat</span>
           <span className="font-bold text-red-400">{run.combatIndex + 1} / 3</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-400">PV perdus</span>
+          <span className="font-bold text-red-400">{hpLost}</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-400">Dégâts infligés</span>
+          <span className="font-bold text-orange-300">{totalDamageDealt}</span>
         </div>
         <div className="flex justify-between text-sm">
           <span className="text-gray-400">Cartes ajoutées</span>

--- a/src/ui/run/RunMapScreen.tsx
+++ b/src/ui/run/RunMapScreen.tsx
@@ -1,0 +1,97 @@
+import { useGameStore } from '../../store/gameStore.js';
+
+const STEP_LABELS = ['Combat 1', 'Combat 2', 'Combat 3'];
+
+function StepIndicator({ index, combatIndex }: { index: number; combatIndex: number }) {
+  const done = combatIndex > index;
+  const current = combatIndex === index;
+
+  const ring = done
+    ? 'border-green-500 bg-green-900/60 text-green-300'
+    : current
+      ? 'border-yellow-400 bg-yellow-900/40 text-yellow-300 ring-2 ring-yellow-400/40'
+      : 'border-gray-600 bg-gray-900/40 text-gray-500';
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className={`flex h-12 w-12 items-center justify-center rounded-full border-2 text-lg font-bold transition-all ${ring}`}
+        aria-label={`${STEP_LABELS[index]} ${done ? 'terminé' : current ? 'en cours' : 'à venir'}`}
+      >
+        {done ? '✓' : current ? '⚔' : '○'}
+      </div>
+      <span className={`text-xs font-semibold ${current ? 'text-yellow-300' : done ? 'text-green-400' : 'text-gray-500'}`}>
+        {STEP_LABELS[index]}
+      </span>
+    </div>
+  );
+}
+
+export function RunMapScreen() {
+  const run = useGameStore(s => s.run);
+  const startRunCombat = useGameStore(s => s.startRunCombat);
+
+  if (!run) return null;
+
+  const { combatIndex, heroHp, heroMaxHp, playerDeck } = run;
+  const hpPercent = Math.max(0, Math.round((heroHp / heroMaxHp) * 100));
+  const isFirstCombat = combatIndex === 0;
+  const btnLabel = isFirstCombat ? 'Commencer le voyage' : 'Commencer le combat';
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-950 to-black flex flex-col items-center justify-center gap-10 px-4 py-12">
+      <header className="text-center space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
+          Voyage de Sankofa
+        </p>
+        <h1 className="text-4xl font-black text-white">
+          Combat {combatIndex + 1} / 3
+        </h1>
+      </header>
+
+      {/* Journey steps */}
+      <div className="flex items-center gap-4" role="list" aria-label="Étapes du voyage">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="flex items-center gap-4" role="listitem">
+            <StepIndicator index={i} combatIndex={combatIndex} />
+            {i < 2 && <div className="h-px w-10 bg-gray-700" />}
+          </div>
+        ))}
+      </div>
+
+      {/* Hero stats */}
+      <div className="w-full max-w-sm rounded-2xl border border-gray-800 bg-gray-950/80 p-6 space-y-4">
+        <div className="space-y-1">
+          <div className="flex justify-between text-sm font-semibold">
+            <span className="text-gray-400">PV du héros</span>
+            <span className="text-white">{heroHp} / {heroMaxHp}</span>
+          </div>
+          <div className="h-3 w-full rounded-full bg-gray-800 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-red-600 to-red-400 transition-all"
+              style={{ width: `${hpPercent}%` }}
+              role="progressbar"
+              aria-valuenow={heroHp}
+              aria-valuemin={0}
+              aria-valuemax={heroMaxHp}
+              aria-label="Points de vie"
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-400">Cartes dans le deck</span>
+          <span className="font-bold text-blue-300">{playerDeck.length}</span>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={startRunCombat}
+        className="rounded-full bg-yellow-500 px-12 py-4 text-lg font-black text-black shadow-lg shadow-yellow-500/25 transition-transform duration-200 hover:scale-[1.02] hover:bg-yellow-400 active:scale-[0.98]"
+      >
+        {btnLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/ui/run/RunMapScreen.tsx
+++ b/src/ui/run/RunMapScreen.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import { useGameStore } from '../../store/gameStore.js';
 
 const STEP_LABELS = ['Combat 1', 'Combat 2', 'Combat 3'];
@@ -66,10 +67,12 @@ export function RunMapScreen() {
             <span className="text-gray-400">PV du héros</span>
             <span className="text-white">{heroHp} / {heroMaxHp}</span>
           </div>
-          <div className="h-3 w-full rounded-full bg-gray-800 overflow-hidden">
+          <div
+            className="h-3 w-full rounded-full bg-gray-800 overflow-hidden"
+            style={{ '--hp': `${hpPercent}%` } as CSSProperties}
+          >
             <div
-              className="h-full rounded-full bg-gradient-to-r from-red-600 to-red-400 transition-all"
-              style={{ width: `${hpPercent}%` }}
+              className="h-full rounded-full bg-gradient-to-r from-red-600 to-red-400 transition-all [width:var(--hp)]"
               role="progressbar"
               aria-valuenow={heroHp}
               aria-valuemin={0}

--- a/src/ui/run/RunRouter.tsx
+++ b/src/ui/run/RunRouter.tsx
@@ -1,0 +1,39 @@
+import { useGameStore } from '../../store/gameStore.js';
+import { Board } from '../../components/Board/Board.js';
+import { CardSelectionScreen } from './CardSelectionScreen.js';
+import { RunMapScreen } from './RunMapScreen.js';
+import { VictoryScreen } from './VictoryScreen.js';
+import { DefeatScreen } from './DefeatScreen.js';
+
+export function RunRouter() {
+  const run = useGameStore(s => s.run);
+  const selectRunCard = useGameStore(s => s.selectRunCard);
+  const phase = run?.phase;
+
+  switch (phase) {
+    case 'starting':
+      return <RunMapScreen />;
+
+    case 'combat':
+      return <Board />;
+
+    case 'card_selection':
+      if (!run?.cardChoices) return null;
+      return (
+        <CardSelectionScreen
+          cardChoices={run.cardChoices}
+          onSelect={selectRunCard}
+          combatIndex={run.combatIndex as 0 | 1}
+        />
+      );
+
+    case 'victory':
+      return <VictoryScreen />;
+
+    case 'defeat':
+      return <DefeatScreen />;
+
+    default:
+      return null;
+  }
+}

--- a/src/ui/run/VictoryScreen.tsx
+++ b/src/ui/run/VictoryScreen.tsx
@@ -1,0 +1,73 @@
+import { useGameStore } from '../../store/gameStore.js';
+
+const INITIAL_DECK_SIZE = 20;
+
+export function VictoryScreen() {
+  const run = useGameStore(s => s.run);
+  const resetRun = useGameStore(s => s.resetRun);
+  const initRun = useGameStore(s => s.initRun);
+
+  if (!run) return null;
+
+  const cardsAdded = run.playerDeck.length - INITIAL_DECK_SIZE;
+
+  function handleReplay() {
+    resetRun();
+    initRun(run!.faction as 'orisha' | 'zulu');
+  }
+
+  function handleHome() {
+    resetRun();
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-black flex flex-col items-center justify-center gap-8 px-4 py-12">
+      <div className="text-center space-y-4">
+        <div className="text-7xl">🏆</div>
+        <h1 className="text-5xl font-black text-amber-400">Sankofa accompli</h1>
+        <p className="text-gray-300 text-lg max-w-md mx-auto">
+          Le voyage s'achève. Les trois épreuves ont été surmontées.
+        </p>
+      </div>
+
+      <div className="w-full max-w-sm rounded-2xl border border-amber-800/40 bg-amber-950/20 p-6 space-y-3">
+        <h2 className="text-center text-sm font-bold uppercase tracking-widest text-amber-400/80 mb-4">
+          Récapitulatif
+        </h2>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-400">Combats gagnés</span>
+          <span className="font-bold text-green-400">3 / 3</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-400">PV héros final</span>
+          <span className="font-bold text-white">{run.heroHp} / {run.heroMaxHp}</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-400">Cartes ajoutées</span>
+          <span className="font-bold text-blue-300">{cardsAdded}</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-400">Taille du deck final</span>
+          <span className="font-bold text-blue-300">{run.playerDeck.length}</span>
+        </div>
+      </div>
+
+      <div className="flex gap-4">
+        <button
+          type="button"
+          onClick={handleReplay}
+          className="rounded-full bg-yellow-500 px-10 py-3 text-base font-black text-black shadow-lg shadow-yellow-500/25 transition-transform duration-200 hover:scale-[1.02] hover:bg-yellow-400 active:scale-[0.98]"
+        >
+          Rejouer
+        </button>
+        <button
+          type="button"
+          onClick={handleHome}
+          className="rounded-full bg-gray-700 px-10 py-3 text-base font-bold text-white transition-transform duration-200 hover:scale-[1.02] hover:bg-gray-600 active:scale-[0.98]"
+        >
+          Retour à l'accueil
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/run/tests/DefeatScreen.test.tsx
+++ b/src/ui/run/tests/DefeatScreen.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DefeatScreen } from '../DefeatScreen.js';
+import * as storeModule from '../../../store/gameStore.js';
+import type { RunState } from '../../../engine/run/runState.js';
+
+vi.mock('../../../store/gameStore.js', () => ({
+  useGameStore: vi.fn(),
+}));
+
+const useGameStoreMock = storeModule.useGameStore as unknown as ReturnType<typeof vi.fn>;
+
+function makeRun(overrides: Partial<RunState> = {}): Partial<RunState> {
+  return {
+    phase: 'defeat',
+    combatIndex: 1,
+    heroHp: 0,
+    heroMaxHp: 30,
+    faction: 'orisha',
+    playerDeck: new Array(21).fill({ id: 'X' }),
+    cardChoices: null,
+    ...overrides,
+  };
+}
+
+const resetRun = vi.fn();
+const initRun = vi.fn();
+
+beforeEach(() => {
+  resetRun.mockReset();
+  initRun.mockReset();
+  useGameStoreMock.mockImplementation((selector: (s: object) => unknown) =>
+    selector({ run: makeRun(), resetRun, initRun }),
+  );
+});
+
+describe('DefeatScreen', () => {
+  it('returns null when run is null', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: null, resetRun, initRun }),
+    );
+    const { container } = render(<DefeatScreen />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows defeat title', () => {
+    render(<DefeatScreen />);
+    expect(screen.getByText(/Le voyage s'arrête ici/i)).toBeTruthy();
+  });
+
+  it('shows combat index where defeat occurred (combatIndex + 1 / 3)', () => {
+    render(<DefeatScreen />);
+    expect(screen.getByText('2 / 3')).toBeTruthy();
+  });
+
+  it('defeat at combat 0 shows 1 / 3', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: makeRun({ combatIndex: 0 }), resetRun, initRun }),
+    );
+    render(<DefeatScreen />);
+    expect(screen.getByText('1 / 3')).toBeTruthy();
+  });
+
+  it('shows cards added (playerDeck.length - 20)', () => {
+    render(<DefeatScreen />);
+    // playerDeck.length = 21, cards added = 1
+    expect(screen.getByText('1')).toBeTruthy();
+  });
+
+  it('shows 2 buttons: Réessayer and Retour', () => {
+    render(<DefeatScreen />);
+    expect(screen.getByRole('button', { name: /réessayer/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /retour/i })).toBeTruthy();
+  });
+
+  it('"Réessayer" resets and starts a new run with same faction', () => {
+    render(<DefeatScreen />);
+    fireEvent.click(screen.getByRole('button', { name: /réessayer/i }));
+    expect(resetRun).toHaveBeenCalledTimes(1);
+    expect(initRun).toHaveBeenCalledWith('orisha');
+  });
+
+  it('"Retour" calls resetRun only', () => {
+    render(<DefeatScreen />);
+    fireEvent.click(screen.getByRole('button', { name: /retour/i }));
+    expect(resetRun).toHaveBeenCalledTimes(1);
+    expect(initRun).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/run/tests/DefeatScreen.test.tsx
+++ b/src/ui/run/tests/DefeatScreen.test.tsx
@@ -31,14 +31,14 @@ beforeEach(() => {
   resetRun.mockReset();
   initRun.mockReset();
   useGameStoreMock.mockImplementation((selector: (s: object) => unknown) =>
-    selector({ run: makeRun(), resetRun, initRun }),
+    selector({ run: makeRun(), resetRun, initRun, runTotalDamageDealt: 0 }),
   );
 });
 
 describe('DefeatScreen', () => {
   it('returns null when run is null', () => {
     useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
-      sel({ run: null, resetRun, initRun }),
+      sel({ run: null, resetRun, initRun, runTotalDamageDealt: 0 }),
     );
     const { container } = render(<DefeatScreen />);
     expect(container.firstChild).toBeNull();
@@ -56,7 +56,7 @@ describe('DefeatScreen', () => {
 
   it('defeat at combat 0 shows 1 / 3', () => {
     useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
-      sel({ run: makeRun({ combatIndex: 0 }), resetRun, initRun }),
+      sel({ run: makeRun({ combatIndex: 0 }), resetRun, initRun, runTotalDamageDealt: 0 }),
     );
     render(<DefeatScreen />);
     expect(screen.getByText('1 / 3')).toBeTruthy();
@@ -72,6 +72,20 @@ describe('DefeatScreen', () => {
     render(<DefeatScreen />);
     expect(screen.getByRole('button', { name: /réessayer/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /retour/i })).toBeTruthy();
+  });
+
+  it('shows HP lost (heroMaxHp - heroHp)', () => {
+    render(<DefeatScreen />);
+    // heroHp: 0, heroMaxHp: 30 → PV perdus = 30
+    expect(screen.getByText('30')).toBeTruthy();
+  });
+
+  it('shows total damage dealt', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: makeRun(), resetRun, initRun, runTotalDamageDealt: 42 }),
+    );
+    render(<DefeatScreen />);
+    expect(screen.getByText('42')).toBeTruthy();
   });
 
   it('"Réessayer" resets and starts a new run with same faction', () => {

--- a/src/ui/run/tests/RunMapScreen.test.tsx
+++ b/src/ui/run/tests/RunMapScreen.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RunMapScreen } from '../RunMapScreen.js';
+import * as storeModule from '../../../store/gameStore.js';
+import type { RunState } from '../../../engine/run/runState.js';
+
+vi.mock('../../../store/gameStore.js', () => ({
+  useGameStore: vi.fn(),
+}));
+
+const useGameStoreMock = storeModule.useGameStore as unknown as ReturnType<typeof vi.fn>;
+
+function makeRun(overrides: Partial<RunState> = {}): Partial<RunState> {
+  return {
+    phase: 'starting',
+    combatIndex: 0,
+    heroHp: 30,
+    heroMaxHp: 30,
+    playerDeck: new Array(20).fill({ id: 'X' }),
+    cardChoices: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useGameStoreMock.mockImplementation((selector: (s: object) => unknown) =>
+    selector({ run: makeRun(), startRunCombat: vi.fn() }),
+  );
+});
+
+describe('RunMapScreen', () => {
+  it('returns null when run is null', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: null, startRunCombat: vi.fn() }),
+    );
+    const { container } = render(<RunMapScreen />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('displays 3 step indicators', () => {
+    render(<RunMapScreen />);
+    const steps = screen.getByRole('list', { name: /étapes du voyage/i });
+    expect(steps.querySelectorAll('[role="listitem"]')).toHaveLength(3);
+  });
+
+  it('shows correct combat title for combatIndex 0', () => {
+    render(<RunMapScreen />);
+    expect(screen.getByText('Combat 1 / 3')).toBeTruthy();
+  });
+
+  it('shows "Commencer le voyage" button for combat 0', () => {
+    render(<RunMapScreen />);
+    expect(screen.getByRole('button', { name: /commencer le voyage/i })).toBeTruthy();
+  });
+
+  it('shows "Commencer le combat" button for combat > 0', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: makeRun({ combatIndex: 1 }), startRunCombat: vi.fn() }),
+    );
+    render(<RunMapScreen />);
+    expect(screen.getByRole('button', { name: /commencer le combat/i })).toBeTruthy();
+  });
+
+  it('displays hero HP correctly', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: makeRun({ heroHp: 12, heroMaxHp: 30 }), startRunCombat: vi.fn() }),
+    );
+    render(<RunMapScreen />);
+    expect(screen.getByText('12 / 30')).toBeTruthy();
+  });
+
+  it('displays deck size', () => {
+    render(<RunMapScreen />);
+    expect(screen.getByText('20')).toBeTruthy();
+  });
+
+  it('clicking "Commencer" calls startRunCombat', () => {
+    const startRunCombat = vi.fn();
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: makeRun(), startRunCombat }),
+    );
+    render(<RunMapScreen />);
+    fireEvent.click(screen.getByRole('button', { name: /commencer/i }));
+    expect(startRunCombat).toHaveBeenCalledTimes(1);
+  });
+
+  it('first step is current (⚔) at combatIndex 0, others are future (○)', () => {
+    render(<RunMapScreen />);
+    const listItems = screen.getByRole('list').querySelectorAll('[role="listitem"]');
+    expect(listItems[0].textContent).toContain('⚔');
+    expect(listItems[1].textContent).toContain('○');
+    expect(listItems[2].textContent).toContain('○');
+  });
+
+  it('first step shows ✓ at combatIndex 1 (completed)', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: makeRun({ combatIndex: 1 }), startRunCombat: vi.fn() }),
+    );
+    render(<RunMapScreen />);
+    const listItems = screen.getByRole('list').querySelectorAll('[role="listitem"]');
+    expect(listItems[0].textContent).toContain('✓');
+    expect(listItems[1].textContent).toContain('⚔');
+  });
+});

--- a/src/ui/run/tests/RunRouter.test.tsx
+++ b/src/ui/run/tests/RunRouter.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RunRouter } from '../RunRouter.js';
+import * as storeModule from '../../../store/gameStore.js';
+import type { RunState } from '../../../engine/run/runState.js';
+import type { Card } from '../../../engine/types.js';
+
+vi.mock('../../../store/gameStore.js', () => ({
+  useGameStore: vi.fn(),
+}));
+
+// Silence child component render errors (Board, CardSelectionScreen need full store)
+vi.mock('../../../components/Board/Board.js', () => ({
+  Board: () => <div data-testid="board">Board</div>,
+}));
+vi.mock('../CardSelectionScreen.js', () => ({
+  CardSelectionScreen: () => <div data-testid="card-selection">CardSelection</div>,
+}));
+vi.mock('../RunMapScreen.js', () => ({
+  RunMapScreen: () => <div data-testid="run-map">RunMapScreen</div>,
+}));
+vi.mock('../VictoryScreen.js', () => ({
+  VictoryScreen: () => <div data-testid="victory">VictoryScreen</div>,
+}));
+vi.mock('../DefeatScreen.js', () => ({
+  DefeatScreen: () => <div data-testid="defeat">DefeatScreen</div>,
+}));
+
+function mockRun(phase: RunState['phase']): Partial<RunState> {
+  return {
+    phase,
+    combatIndex: 0,
+    cardChoices: phase === 'card_selection'
+      ? [{ id: 'C1' } as Card, { id: 'C2' } as Card, { id: 'C3' } as Card]
+      : null,
+  };
+}
+
+const useGameStoreMock = storeModule.useGameStore as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  useGameStoreMock.mockImplementation((selector: (s: object) => unknown) =>
+    selector({ run: null, selectRunCard: vi.fn() }),
+  );
+});
+
+describe('RunRouter', () => {
+  it('returns null when run is null', () => {
+    const { container } = render(<RunRouter />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders RunMapScreen for phase starting', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: mockRun('starting'), selectRunCard: vi.fn() }),
+    );
+    render(<RunRouter />);
+    expect(screen.getByTestId('run-map')).toBeTruthy();
+  });
+
+  it('renders Board for phase combat', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: mockRun('combat'), selectRunCard: vi.fn() }),
+    );
+    render(<RunRouter />);
+    expect(screen.getByTestId('board')).toBeTruthy();
+  });
+
+  it('renders CardSelectionScreen for phase card_selection', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: mockRun('card_selection'), selectRunCard: vi.fn() }),
+    );
+    render(<RunRouter />);
+    expect(screen.getByTestId('card-selection')).toBeTruthy();
+  });
+
+  it('renders VictoryScreen for phase victory', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: mockRun('victory'), selectRunCard: vi.fn() }),
+    );
+    render(<RunRouter />);
+    expect(screen.getByTestId('victory')).toBeTruthy();
+  });
+
+  it('renders DefeatScreen for phase defeat', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: mockRun('defeat'), selectRunCard: vi.fn() }),
+    );
+    render(<RunRouter />);
+    expect(screen.getByTestId('defeat')).toBeTruthy();
+  });
+});

--- a/src/ui/run/tests/VictoryScreen.test.tsx
+++ b/src/ui/run/tests/VictoryScreen.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { VictoryScreen } from '../VictoryScreen.js';
+import * as storeModule from '../../../store/gameStore.js';
+import type { RunState } from '../../../engine/run/runState.js';
+
+vi.mock('../../../store/gameStore.js', () => ({
+  useGameStore: vi.fn(),
+}));
+
+const useGameStoreMock = storeModule.useGameStore as unknown as ReturnType<typeof vi.fn>;
+
+function makeRun(overrides: Partial<RunState> = {}): Partial<RunState> {
+  return {
+    phase: 'victory',
+    combatIndex: 2,
+    heroHp: 18,
+    heroMaxHp: 30,
+    faction: 'zulu',
+    playerDeck: new Array(22).fill({ id: 'X' }),
+    cardChoices: null,
+    ...overrides,
+  };
+}
+
+const resetRun = vi.fn();
+const initRun = vi.fn();
+
+beforeEach(() => {
+  resetRun.mockReset();
+  initRun.mockReset();
+  useGameStoreMock.mockImplementation((selector: (s: object) => unknown) =>
+    selector({ run: makeRun(), resetRun, initRun }),
+  );
+});
+
+describe('VictoryScreen', () => {
+  it('returns null when run is null', () => {
+    useGameStoreMock.mockImplementation((sel: (s: object) => unknown) =>
+      sel({ run: null, resetRun, initRun }),
+    );
+    const { container } = render(<VictoryScreen />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows victory title', () => {
+    render(<VictoryScreen />);
+    expect(screen.getByText(/Sankofa accompli/i)).toBeTruthy();
+  });
+
+  it('shows combats won 3/3', () => {
+    render(<VictoryScreen />);
+    expect(screen.getByText('3 / 3')).toBeTruthy();
+  });
+
+  it('shows hero HP', () => {
+    render(<VictoryScreen />);
+    expect(screen.getByText('18 / 30')).toBeTruthy();
+  });
+
+  it('shows cards added (playerDeck.length - 20)', () => {
+    render(<VictoryScreen />);
+    expect(screen.getByText('2')).toBeTruthy();
+  });
+
+  it('shows 2 buttons: Rejouer and Retour', () => {
+    render(<VictoryScreen />);
+    expect(screen.getByRole('button', { name: /rejouer/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /retour/i })).toBeTruthy();
+  });
+
+  it('"Rejouer" resets run and starts a new one with same faction', () => {
+    render(<VictoryScreen />);
+    fireEvent.click(screen.getByRole('button', { name: /rejouer/i }));
+    expect(resetRun).toHaveBeenCalledTimes(1);
+    expect(initRun).toHaveBeenCalledWith('zulu');
+  });
+
+  it('"Retour" calls resetRun only', () => {
+    render(<VictoryScreen />);
+    fireEvent.click(screen.getByRole('button', { name: /retour/i }));
+    expect(resetRun).toHaveBeenCalledTimes(1);
+    expect(initRun).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #42

## Provenance
<!-- author:cursor -->
author:cursor

## Contexte
Ticket framing M4. Pose le routing entre toutes les phases du run et les 3 écrans manquants. Une fois mergée, une run Sankofa est jouable end-to-end. Mode hot-seat M2 préservé via "Partie libre".

## Modifications
- `src/ui/run/RunRouter.tsx` — switch sur RunState.phase, dispatche vers le bon écran
- `src/ui/run/RunMapScreen.tsx` — carte du voyage (3 étapes, HP bar, deck size, bouton combat)
- `src/ui/run/VictoryScreen.tsx` — fin de run gagnante (stats + rejouer/accueil)
- `src/ui/run/DefeatScreen.tsx` — fin de run perdante (stats + réessayer/accueil)
- `src/store/gameStore.ts` — actions initRun/startRunCombat/resetRun + dispatch run-aware via applyCombatTurn
- `src/App.tsx` — if (run !== null) → RunRouter, sinon hot-seat existant
- `src/screens/FactionSelect.tsx` — bouton "Commencer le voyage" (mode solo vs IA) + "Partie libre" (hot-seat)
- `src/ui/run/tests/` — 4 nouveaux fichiers RTL (RunRouter × 6, RunMapScreen × 10, VictoryScreen × 8, DefeatScreen × 8)

## Critères d'acceptation
- [x] Run jouable end-to-end (FactionSelect → 3 combats → victoire ou défaite)
- [x] Mode hot-seat M2 préservé (bouton "Partie libre")
- [x] 193/193 tests verts, coverage gate engine ✅ (89.5% statements)
- [x] Aucune modification de src/engine/run/ ou src/engine/ai/
- [x] Build propre (tsc + vite build)

## Architecture dispatch run-aware
En mode run (run.phase === combat), dispatch synchronise gameState → run.currentCombat puis appelle applyCombatTurn pour tout type d'action. Gère : gameover par ATTACK, AI turn après END_TURN, heroHp sync. Pas de hot-seat en run mode (p2 = IA).

## Note stats finales
cardsAdded = playerDeck.length - 20 (taille initiale assumée). Aucun champ RunState ajouté.

## Verdict QA initial
<!-- verdict:start -->
qa-pending
<!-- verdict:end -->

## Cross-review checklist
- [ ] CI verte (lint + test + build + coverage gate)
- [ ] Dev Reviewer Claude : audit attendu
- [ ] QA Claude : verdict attendu
- [ ] QA Challenger Claude : second avis + test adversarial

## Notes pour les reviewers
- Pas de proverbe Sankofa : c'est #43.
- Pas d'animation Framer Motion : Tailwind uniquement.
- Pas de rebalance decks : TODO M5.
